### PR TITLE
feat: more bounds on sig/exp/guard/sticky during rounding manipulations

### DIFF
--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -339,45 +339,56 @@ theorem toInt_ofInt_minNormalExp_eq_minNormalExp (he : 1 < e) (hs : 0 < s) :
     simp only [Int.natCast_pow, Int.cast_ofNat_Int, gt_iff_lt]
     grind only
 
+theorem neg_two_pow_le_minNormalExp
+    (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w) :
+    -(↑(2 ^ w) / 2) ≤ minNormalExp e := by
+  rw [minNormalExp]
+  simp only [Int.neg_le_neg_iff]
+  have : 0 < bias e := by exact bias_pos_of_one_lt e he
+  rw [Int.natCast_sub (by grind only)]
+  simp
+  have := bias_plus_one_lt_two_pow_exponentWidth_minus_one e s he hs
+  have : (2 : Int) ^ w / 2 = 2 ^ (w - 1) := by
+    rw [Int.two_pow_div_two_eq_sub_one_of_pos]
+    grind only
+  have : 2 ^ (exponentWidth e s - 1) ≤ 2 ^ (w - 1) := by
+    apply Nat.pow_le_pow_of_le
+    · decide
+    · grind only
+  grind only
+
+theorem minNormalExp_lt_two_pow
+    (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w) :
+    minNormalExp e < (↑(2 ^ w) + 1) / 2:= by
+  rw [minNormalExp]
+  simp only [Int.two_pow_plus_one_div_two_eq_two_pow]
+  apply Int.lt_of_neg_lt_neg
+  simp only [Int.neg_neg]
+  have : 0 < bias e := by exact bias_pos_of_one_lt e he
+  rw [Int.natCast_sub (by grind only)]
+  simp only [Int.cast_ofNat_Int, gt_iff_lt]
+  have := bias_plus_one_lt_two_pow_exponentWidth_minus_one e s he hs
+  norm_cast
+  simp only [Int.natCast_pow, Int.cast_ofNat_Int, gt_iff_lt]
+  have : 2 ^ (exponentWidth e s - 1) ≤ 2 ^ (w - 1) := by
+    apply Nat.pow_le_pow_of_le
+    · decide
+    · grind only
+  grind only
+
 /--
 Any bitvector that is at least as large as `exponentWidth e s`
 can fit `minNormalExp`
 -/
 theorem toInt_ofInt_minNormalExp_eq_minNormalExp_of_le
-    (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w):
+    (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w) :
     (BitVec.ofInt w (minNormalExp e)).toInt = (minNormalExp e) := by
+  have : 0 < exponentWidth  e s := by exact zero_lt_exponentWidth
+  have : 0 < w := by grind only
   simp only [BitVec.toInt_ofInt]
   rw [Int.bmod_eq_of_le]
-  · simp
-    rw [minNormalExp]
-    simp only [Int.neg_le_neg_iff]
-    have : 0 < bias e := by exact bias_pos_of_one_lt e he
-    rw [Int.natCast_sub (by grind only)]
-    simp
-    have := bias_plus_one_lt_two_pow_exponentWidth_minus_one e s he hs
-    have : (2 : Int) ^ w / 2 = 2 ^ (w - 1) := by
-      rw [Int.two_pow_div_two_eq_sub_one_of_pos]
-      grind only
-    have : 2 ^ (exponentWidth e s - 1) ≤ 2 ^ (w - 1) := by
-      apply Nat.pow_le_pow_of_le
-      · decide
-      · grind only
-    grind
-  · rw [minNormalExp]
-    simp only [Int.natCast_pow, Int.cast_ofNat_Int, Int.two_pow_plus_one_div_two_eq_two_pow]
-    apply Int.lt_of_neg_lt_neg
-    simp only [Int.neg_neg]
-    have : 0 < bias e := by exact bias_pos_of_one_lt e he
-    rw [Int.natCast_sub (by grind only)]
-    simp only [Int.cast_ofNat_Int, gt_iff_lt]
-    have := bias_plus_one_lt_two_pow_exponentWidth_minus_one e s he hs
-    norm_cast
-    simp only [Int.natCast_pow, Int.cast_ofNat_Int, gt_iff_lt]
-    have : 2 ^ (exponentWidth e s - 1) ≤ 2 ^ (w - 1) := by
-      apply Nat.pow_le_pow_of_le
-      · decide
-      · grind only
-    grind only
+  · apply neg_two_pow_le_minNormalExp he hs hw
+  · apply minNormalExp_lt_two_pow he hs hw
 
 
 @[simp, grind =]

--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -339,6 +339,47 @@ theorem toInt_ofInt_minNormalExp_eq_minNormalExp (he : 1 < e) (hs : 0 < s) :
     simp only [Int.natCast_pow, Int.cast_ofNat_Int, gt_iff_lt]
     grind only
 
+/--
+Any bitvector that is at least as large as `exponentWidth e s`
+can fit `minNormalExp`
+-/
+theorem toInt_ofInt_minNormalExp_eq_minNormalExp_of_le
+    (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w):
+    (BitVec.ofInt w (minNormalExp e)).toInt = (minNormalExp e) := by
+  simp only [BitVec.toInt_ofInt]
+  rw [Int.bmod_eq_of_le]
+  · simp
+    rw [minNormalExp]
+    simp only [Int.neg_le_neg_iff]
+    have : 0 < bias e := by exact bias_pos_of_one_lt e he
+    rw [Int.natCast_sub (by grind only)]
+    simp
+    have := bias_plus_one_lt_two_pow_exponentWidth_minus_one e s he hs
+    have : (2 : Int) ^ w / 2 = 2 ^ (w - 1) := by
+      rw [Int.two_pow_div_two_eq_sub_one_of_pos]
+      grind only
+    have : 2 ^ (exponentWidth e s - 1) ≤ 2 ^ (w - 1) := by
+      apply Nat.pow_le_pow_of_le
+      · decide
+      · grind only
+    grind
+  · rw [minNormalExp]
+    simp only [Int.natCast_pow, Int.cast_ofNat_Int, Int.two_pow_plus_one_div_two_eq_two_pow]
+    apply Int.lt_of_neg_lt_neg
+    simp only [Int.neg_neg]
+    have : 0 < bias e := by exact bias_pos_of_one_lt e he
+    rw [Int.natCast_sub (by grind only)]
+    simp only [Int.cast_ofNat_Int, gt_iff_lt]
+    have := bias_plus_one_lt_two_pow_exponentWidth_minus_one e s he hs
+    norm_cast
+    simp only [Int.natCast_pow, Int.cast_ofNat_Int, gt_iff_lt]
+    have : 2 ^ (exponentWidth e s - 1) ≤ 2 ^ (w - 1) := by
+      apply Nat.pow_le_pow_of_le
+      · decide
+      · grind only
+    grind only
+
+
 @[simp, grind =]
 theorem toInt_ofInt_maxNormalExp_eq_maxNormalExp (he : 1 < e) (hs : 0 < s) :
     (BitVec.ofInt (exponentWidth e s) (maxNormalExp e)).toInt = (maxNormalExp e) := by

--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -341,7 +341,7 @@ theorem toInt_ofInt_minNormalExp_eq_minNormalExp (he : 1 < e) (hs : 0 < s) :
 
 theorem neg_two_pow_le_minNormalExp
     (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w) :
-    -(↑(2 ^ w) / 2) ≤ minNormalExp e := by
+    -(2 ^ (w - 1)) ≤ minNormalExp e := by
   rw [minNormalExp]
   simp only [Int.neg_le_neg_iff]
   have : 0 < bias e := by exact bias_pos_of_one_lt e he
@@ -357,11 +357,12 @@ theorem neg_two_pow_le_minNormalExp
     · grind only
   grind only
 
+grind_pattern neg_two_pow_le_minNormalExp => exponentWidth e s ≤ w, minNormalExp e
+
 theorem minNormalExp_lt_two_pow
     (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w) :
-    minNormalExp e < (↑(2 ^ w) + 1) / 2:= by
+    minNormalExp e < 2 ^ (w - 1):= by
   rw [minNormalExp]
-  simp only [Int.two_pow_plus_one_div_two_eq_two_pow]
   apply Int.lt_of_neg_lt_neg
   simp only [Int.neg_neg]
   have : 0 < bias e := by exact bias_pos_of_one_lt e he
@@ -376,6 +377,8 @@ theorem minNormalExp_lt_two_pow
     · grind only
   grind only
 
+grind_pattern minNormalExp_lt_two_pow => exponentWidth e s ≤ w, minNormalExp e
+
 /--
 Any bitvector that is at least as large as `exponentWidth e s`
 can fit `minNormalExp`
@@ -384,11 +387,14 @@ theorem toInt_ofInt_minNormalExp_eq_minNormalExp_of_le
     (he : 1 < e) (hs : 0 < s) (hw : exponentWidth e s ≤ w) :
     (BitVec.ofInt w (minNormalExp e)).toInt = (minNormalExp e) := by
   have : 0 < exponentWidth  e s := by exact zero_lt_exponentWidth
-  have : 0 < w := by grind only
+  have hwpos : 0 < w := by grind only
   simp only [BitVec.toInt_ofInt]
   rw [Int.bmod_eq_of_le]
-  · apply neg_two_pow_le_minNormalExp he hs hw
-  · apply minNormalExp_lt_two_pow he hs hw
+  · simp only [Int.natCast_pow, Int.cast_ofNat_Int, hwpos, Int.two_pow_div_two_eq_sub_one_of_pos];
+    apply neg_two_pow_le_minNormalExp he hs hw
+  · simp; apply minNormalExp_lt_two_pow he hs hw
+
+grind_pattern toInt_ofInt_minNormalExp_eq_minNormalExp_of_le => exponentWidth e s ≤ w, minNormalExp e
 
 
 @[simp, grind =]

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1599,51 +1599,164 @@ theorem BitVec.toNat_zeroExtend_of_lt {n m : Nat} (bv : BitVec n) (h : bv.toNat 
   rw [Nat.mod_eq_of_lt]
   grind only
 
+@[simp]
+theorem Int.sub_toNat_eq_zero_of_le {a b : Int} (h : a ≤ b) :
+    (a - b).toNat = 0 := by
+  simp
+  grind only
 
 
-
+/--
+The guard bit index when interpreted as a natural number
+gives us the location of the guard bit inside the unpaked float.
+sorry
+-/
 theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
-    (heusu : eu ≤ su)
+    -- (heusu : eu ≤ su)
     (x : UnpackedFloat eu su) :
-    (x.guardBitIndex ep sp).toNat = 1 := by
+    (x.guardBitIndex ep sp).toNat =
+    (su - 1 - (sp + 1) + (minNormalExp ep - x.ex.toInt).toNat) := by
+  have := @one_lt_exponentWidth ep sp
+  have hminNormal : (BitVec.ofInt eu (minNormalExp ep)).toInt = minNormalExp ep := by
+    rw [toInt_ofInt_minNormalExp_eq_minNormalExp_of_le (s := sp)]
+    · grind only
+    · grind only
+    · grind only
+
   rw [UnpackedFloat.guardBitIndex]
-  split
-  case isTrue h =>
-    rw [BitVec.slt_eq_decide] at h
-    simp only [decide_eq_true_eq] at h
-    rw [toInt_ofInt_minNormalExp_eq_minNormalExp_of_le (e := ep) (s := sp) (w := eu)
-      (by grind only) (by grind only)] at h
-    rw [show su - 1  - (sp + 1) = su - (sp + 2) by grind only]
-    rw [BitVec.zeroExtend_eq_setWidth]
-    rw [BitVec.toNat_add_of_lt]
-    · rw [BitVec.toNat_setWidth_of_le]
-      · sorry
-      · exact heusu
-    · sorry
-    · sorry
-  case isFalse h =>
-    sorry
-
-theorem extractStickyBit_eq_false_iff (x : UnpackedFloat e s) :
-  x.extractStickyBit e s = false ↔
-      ∀ (i : Nat), x.sig.getLsbD i = 0 := by
-  simp [UnpackedFloat.extractStickyBit]
-
-
-@[simp]
-theorem UnpackedFloat.extractStickyBit_eq_not_tieBreak_of_nonneg_of_guardBit (x : UnpackedFloat e s)
-    (hx : x.sign = false)
-    (hguard : x.extractGuardBit e s = true) :
-    x.extractStickyBit e s = ! (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).tieBreak (ExtRat.Number x.toRat) := by
-  simp [UnpackedFloat.extractStickyBit]
-  simp [SmtLibSemantics.smtLibRoundMethod]
-  constructor
-  · intros h
-    sorry
+  rw [BitVec.toNat_add]
+  simp
+  rw [BitVec.toNat_subSaturatingZero_eq_ite_toNat]
+  · simp only [hminNormal]
+    split
+    case isTrue h =>
+      simp
+      rw [Int.sub_toNat_eq_zero_of_le]
+      · simp
+        rw [Nat.mod_eq_of_lt]
+        · sorry
+      · grind only
+    case isFalse h =>
+      simp at h
+      rw [Nat.mod_eq_of_lt]
+      sorry
+  · grind only
+  · sorry
   · sorry
 
+theorem BitVec.eq_iff_getLsbD_eq (a b : BitVec w) : a = b ↔
+    (∀ (i : Nat), a.getLsbD i = b.getLsbD i) := by
+  constructor
+  · intros h
+    subst h
+    grind only
+  · intros h
+    ext i hi
+    simp only [← BitVec.getLsbD_eq_getElem]
+    grind only [#0a30]
 
+
+/--
+`p iff q` iff `not p iff not q`.
+-/
+theorem iff_iff_not_iff_not {p q : Prop} :
+    (p ↔ q) ↔ (¬ p ↔ ¬ q) := by
+  grind
+
+theorem extractStickyBit_eq_true_iff
+  (hep : 1 < ep) (hsp : 0 < sp)
+  (heu : exponentWidth ep sp ≤ eu)
+  (hsu : sp + 2 ≤ su)
+  (x : UnpackedFloat eu su) :
+  x.extractStickyBit ep sp = true ↔
+    -- This makes sense,
+    -- Consider when `su = sp + 2`.
+    -- Then we're saying that some bit
+    -- after the guard bit is nonzero.
+     (∃ (i : Nat),
+      i < su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat ∧
+      x.sig.getLsbD i = true) := by
+  simp [UnpackedFloat.extractStickyBit]
+  rw [UnpackedFloat.toNat_guardBitIndex_eq]
+  rw [show (su - 1 - (sp + 1)) = su - (sp + 2) by grind only]
+  rw [show su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat =
+       ((su + (minNormalExp ep - x.ex.toInt).toNat)) - (sp + 2) by grind only]
+  · rw [show (su - (su + (minNormalExp ep - x.ex.toInt).toNat - (sp + 2))) =
+        (sp + 2 - (minNormalExp ep - x.ex.toInt).toNat) by grind only]
+    constructor
+    · intros heq
+      rw [BitVec.eq_iff_getLsbD_eq] at heq
+      simp at heq
+      obtain ⟨i, hi⟩ := heq
+      exists i
+      grind only
+    · intros h
+      simp at h
+      intros hcontra
+      rw [BitVec.eq_iff_getLsbD_eq] at hcontra
+      simp at hcontra
+      obtain ⟨i, hi⟩ := h
+      specialize hcontra i (by grind)
+      obtain ⟨hi1, hi2⟩ := hi
+      grind
+  · grind only
+  · grind only
+  · grind only
+  · grind only
+
+theorem extractStickyBit_eq_false_iff
+  (hep : 1 < ep) (hsp : 0 < sp)
+  (heu : exponentWidth ep sp ≤ eu)
+  (hsu : sp + 2 ≤ su)
+  (x : UnpackedFloat eu su) :
+  x.extractStickyBit ep sp = false ↔
+    -- This makes sense,
+    -- This says that all the lower bits are false.
+     (∀ (i : Nat),
+      i < su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat →
+      x.sig.getLsbD i = false) := by
+  have htrue := extractStickyBit_eq_true_iff hep hsp heu hsu x
+  rw [iff_iff_not_iff_not] at htrue
+  grind only [#c179, #0b53, #b326]
+
+/--
+The sticky bit tracks whether there is a bit
+below the guard bit that is 1.
+This is equivalent to saying that there exists some bit below the guard bit that is 1.
+-/
+theorem extractStickyBit_eq_decide
+  (hep : 1 < ep) (hsp : 0 < sp)
+  (heu : exponentWidth ep sp ≤ eu)
+  (hsu : sp + 2 ≤ su)
+  (x : UnpackedFloat eu su) :
+  x.extractStickyBit ep sp = decide (∃ (i : Nat),
+      i < su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat ∧
+      x.sig.getLsbD i = true) := by
+  by_cases hextract : x.extractStickyBit ep sp = true
+  · have := extractStickyBit_eq_true_iff hep hsp heu hsu x
+    grind only [#46e5, #0b53]
+  · have := extractStickyBit_eq_true_iff hep hsp heu hsu x
+    simp at this
+    grind only [#46e5, #0b53]
+
+@[simp]
+theorem UnpackedFloat.extractStickyBit_eq_not_tieBreak_of_nonneg_of_guardBit
+    (he : 1 < ep)
+    (hs : 0 < sp)
+    (heu : exponentWidth ep sp ≤ eu)
+    (hsu : sp + 2 ≤ su)
+    (x : UnpackedFloat eu su)
+    (hx : x.sign = false)
+    (hguard : x.extractGuardBit ep sp = true) :
+    x.extractStickyBit ep sp = ! (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) ep sp SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).tieBreak (ExtRat.Number x.toRat) := by
+  simp [SmtLibSemantics.smtLibRoundMethod]
+  rw [extractStickyBit_eq_decide]
+  · sorry
+  · grind only
+  · grind only
+  · grind only
+  · grind only
 
 end Fp

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -960,73 +960,92 @@ theorem isEven_upper_eq_not_isEven_lower (eout sout : Nat) (r : Rat) :
   have := isEven_lower_eq_not_isEven_upper eout sout r
   grind only [#9ad2]
 
-axiom embed_lower_le_self {e s : Nat} (r : ExtRat) :
-    SmtLibSemantics.RoundableEmbed.embed
-      (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s) ≤ r -- := by
+/-# IsLawfulLower, smtLibLower, and computable lower
 
-axiom le_lower_of_embed_le
-    {e s : Nat} (r : ExtRat) (lower' : PackedFloat e s)
-    (hlower' : SmtLibSemantics.RoundableEmbed.embed lower' ≤ r) :
-    lower' ≤ SmtLibSemantics.smtLibLower.lower r
-
-
-theorem isLawfulLower_lower (e s : Nat) (r : ExtRat) :
+We show that `smtLibLower` can always be replaced with `lower`
+-/
+theorem lsLawfulLower_smtLibLower (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) :
     SmtLibSemantics.IsLawfulLower r (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s) := by
-  constructor
-  · apply embed_lower_le_self <;> grind only
-  · intros lower' hlower'
-    apply le_lower_of_embed_le <;> grind only
+  simp [SmtLibSemantics.smtLibLower]
+  apply Classical.epsilon_spec
+  have := IsLawfulLower_lower e s he hs r
+  grind only [#de43]
+
+/--
+two lawful lowers are equal to each other.
+-/
+theorem eq_of_IsLawfulLower_of_IsLawfulLower
+    (e s : Nat) (r : ExtRat) (x y : PackedFloat e s)
+    (hxnan : ¬ x.isNaN) (hynan : ¬ y.isNaN)
+    (hlowerx : SmtLibSemantics.IsLawfulLower r x)
+    (hlowery : SmtLibSemantics.IsLawfulLower r y) :
+    x = y := by
+  have rlex := hlowerx.1
+  have rley := hlowery.1
+  have rlex' := hlowerx.2 y rley
+  have rley' := hlowery.2 x rlex
+  grind only [PackedFloat.le_antisymm_of_ne_NaN]
 
 
+theorem IsLawfulLower_eq_NaN_of_isNaN (e s : Nat) (r : ExtRat) (x : PackedFloat e s)
+    (hlower : SmtLibSemantics.IsLawfulLower r x) :
+    x.isNaN = true → r = .NaN := by
+  intros hnan
+  have hlower1 := hlower.1
+  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+    ExtRat.ge_eq_le_symm] at hlower1
+  simp [hnan] at hlower1
+  grind
+
+/--
+The result of 'IsLawfulLower' is unique and must be equal to the 'lower' computation.
+If the value is a 'NaN', then we may have different 'NaNs, but we may not get
+equality on the nose.
+-/
 @[simp]
-theorem not_isNaN_lower_of_ne_NaN (e s : Nat) (r : ExtRat) (hr : r ≠ .NaN) :
-    (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s).isNaN = false := by
-  by_cases hnan : (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s).isNaN
-  · exfalso
-    have hembed := embed_lower_le_self (e := e) (s := s) r
-    simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat'] at hembed
-    rw [PackedFloat.toExtRat'_eq_NaN_of_isNaN _ hnan] at hembed
-    have := (ExtRat.le_NaN _).mp hembed
-    exact hr this
-  · simp [hnan]
+theorem eq_lower_of_IsLawfulLower (e s : Nat) (he : 0 < e) (hs : 0 < s)
+    (r : ExtRat)
+    (x : PackedFloat e s)
+    (hrnan : r ≠ .NaN)
+    (hlower : SmtLibSemantics.IsLawfulLower r x) :
+    x = lower e s he hs r := by
+  apply eq_of_IsLawfulLower_of_IsLawfulLower
+  · intros hcontra
+    apply hrnan
+    apply IsLawfulLower_eq_NaN_of_isNaN
+    · exact hlower
+    · grind only
+  · apply Classical.byContradiction
+    intros hcontra
+    apply hrnan
+    grind [ExtRat, lower]
+  · apply hlower
+  · exact IsLawfulLower_lower e s he hs r
 
 
-@[simp]
-theorem not_isNaN_lower_neg_of_ne_NaN (e s : Nat) (r : ExtRat) (hr : r ≠ .NaN) :
-    (SmtLibSemantics.smtLibLower.lower (-r) : PackedFloat e s).isNaN = false := by
-  apply not_isNaN_lower_of_ne_NaN
-  simp [ExtRat.neg_eq_NaN_iff, hr]
-
-axiom self_le_embed_upper {e s : Nat} (r : ExtRat) :
-    r ≤ SmtLibSemantics.RoundableEmbed.embed
-      (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s) -- := by
-  -- sorry
-
-axiom le_upper_of_self_le_embed
-    {e s : Nat} (r : ExtRat) (upper' : PackedFloat e s)
-    (hupper' : r ≤ SmtLibSemantics.RoundableEmbed.embed upper') :
-    SmtLibSemantics.smtLibUpper.upper r ≤ upper' -- := by
-  -- sorry
+/--
+the value of smtLibLower equals that of 'lower' on all non-NaN rationals.
+-/
+theorem smtLibLower_eq_lower (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
+    SmtLibSemantics.smtLibLower.lower r = lower e s he hs r := by
+  apply eq_of_IsLawfulLower_of_IsLawfulLower (r := r)
+  · intros hcontra
+    sorry
+  · intros hcontra
+    apply hr
+    grind only [→ PackedFloat.not_isZero_of_isNaN, lower, PackedFloat.isZero_getZero, #2962, #90ed]
+  · exact lsLawfulLower_smtLibLower e s he hs r
+  · exact IsLawfulLower_lower e s he hs r
 
 
-@[simp]
-theorem not_isNaN_upper_of_ne_NaN (e s : Nat) (r : ExtRat) (hr : r ≠ .NaN) :
-    (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s).isNaN = false := by
-  by_cases hnan : (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s).isNaN
-  · exfalso
-    have hembed := self_le_embed_upper (e := e) (s := s) r
-    simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat'] at hembed
-    rw [PackedFloat.toExtRat'_eq_NaN_of_isNaN _ hnan] at hembed
-    simp at hembed
-    grind only
-  · simp [hnan]
+/-## Upper -/
 
-theorem isLawfulUpper_upper (e s : Nat) (r : ExtRat) :
+theorem isLawfulUpper_smtLibUpper (e s : Nat) (he : 0 < e)  (hs : 0 < s) (r : ExtRat) :
     SmtLibSemantics.IsLawfulUpper r (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s) := by
-  constructor
-  · apply self_le_embed_upper <;> grind only
-  · intros upper' hupper'
-    apply le_upper_of_self_le_embed <;> grind only
+  simp [SmtLibSemantics.smtLibUpper]
+  apply Classical.epsilon_spec
+  have := IsLawfulUpper_upper e s he hs r
+  grind only [#c7e1]
 
 /--
 two lawful uppers are equal to each other.
@@ -1078,55 +1097,53 @@ theorem eq_upper_of_IsLawfulUpper (e s : Nat) (he : 0 < e) (hs : 0 < s)
   · apply hupper
   · exact IsLawfulUpper_upper e s he hs r
 
-
-
-/--
-two lawful lowers are equal to each other.
--/
-theorem eq_of_IsLawfulLower_of_IsLawfulLower
-    (e s : Nat) (r : ExtRat) (x y : PackedFloat e s)
-    (hxnan : ¬ x.isNaN) (hynan : ¬ y.isNaN)
-    (hlowerx : SmtLibSemantics.IsLawfulLower r x)
-    (hlowery : SmtLibSemantics.IsLawfulLower r y) :
-    x = y := by
-  have rlex := hlowerx.1
-  have rley := hlowery.1
-  have rlex' := hlowerx.2 y rley
-  have rley' := hlowery.2 x rlex
-  grind only [PackedFloat.le_antisymm_of_ne_NaN]
-
-theorem IsLawfulLower_eq_NaN_of_isNaN (e s : Nat) (r : ExtRat) (x : PackedFloat e s)
-    (hlower : SmtLibSemantics.IsLawfulLower r x) :
-    x.isNaN = true → r = .NaN := by
-  intros hnan
-  have hlower1 := hlower.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hlower1
-  simp [hnan] at hlower1
-  grind
-
-/--
-The result of 'IsLawfulLower' is unique and must be equal to the 'lower' computation.
--/
-@[simp]
-theorem eq_lower_of_IsLawfulLower (e s : Nat) (he : 0 < e) (hs : 0 < s)
-    (r : ExtRat)
-    (x : PackedFloat e s)
-    (hrnan : r ≠ .NaN)
-    (hlower : SmtLibSemantics.IsLawfulLower r x) :
-    x = lower e s he hs r := by
-  apply eq_of_IsLawfulLower_of_IsLawfulLower
+theorem smtLibUpper_eq_upper (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
+    SmtLibSemantics.smtLibUpper.upper r = upper e s he hs r := by
+  apply eq_of_IsLawfulUpper_of_IsLawfulUpper (r := r)
   · intros hcontra
-    apply hrnan
-    apply IsLawfulLower_eq_NaN_of_isNaN
-    · exact hlower
-    · grind only
-  · apply Classical.byContradiction
-    intros hcontra
-    apply hrnan
-    grind [ExtRat, lower]
-  · apply hlower
-  · exact IsLawfulLower_lower e s he hs r
+    sorry
+  · intros hcontra
+    apply hr
+    sorry
+  · exact isLawfulUpper_smtLibUpper e s he hs r
+  · exact IsLawfulUpper_upper e s he hs r
+
+
+
+@[simp]
+theorem not_isNaN_lower_of_ne_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
+    (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s).isNaN = false := by
+  rw [smtLibLower_eq_lower e s he hs r hr]
+  grind only [lower, → PackedFloat.not_isZero_of_isNaN, PackedFloat.isZero_getZero, #2962, #90ed]
+
+@[simp]
+theorem not_isNaN_lower_neg_of_ne_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
+    (SmtLibSemantics.smtLibLower.lower (-r) : PackedFloat e s).isNaN = false := by
+  apply not_isNaN_lower_of_ne_NaN e s he hs
+  simp [ExtRat.neg_eq_NaN_iff, hr]
+
+
+
+@[simp]
+theorem not_isNaN_upper_of_ne_NaN (e s : Nat) (r : ExtRat) (hr : r ≠ .NaN) :
+    (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s).isNaN = false := by
+  by_cases hnan : (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s).isNaN
+  · exfalso
+    have hembed := self_le_embed_upper (e := e) (s := s) r
+    simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat'] at hembed
+    rw [PackedFloat.toExtRat'_eq_NaN_of_isNaN _ hnan] at hembed
+    simp at hembed
+    grind only
+  · simp [hnan]
+
+theorem isLawfulUpper_upper (e s : Nat) (r : ExtRat) :
+    SmtLibSemantics.IsLawfulUpper r (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s) := by
+  constructor
+  · apply self_le_embed_upper <;> grind only
+  · intros upper' hupper'
+    apply le_upper_of_self_le_embed <;> grind only
+
+
 
 
 
@@ -1137,78 +1154,23 @@ theorem embed_neg_eq_neg_embed {e s : Nat} (x : PackedFloat e s) :
 
 -- lower(-x) = - upper x
 @[simp]
-theorem lower_neg_eq_neg_upper {e s : Nat} (r : ExtRat) (hr : r ≠ .NaN) :
+theorem lower_neg_eq_neg_upper {e s : Nat} (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
     (SmtLibSemantics.smtLibLower.lower (-r) : PackedFloat e s) = - (SmtLibSemantics.smtLibUpper.upper r) := by
-  have hlower := isLawfulLower_lower e s (-r)
-  have hlower1 := hlower.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hlower1
-  have hlower2 := hlower.2
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hlower2
-
-  have hupper := isLawfulUpper_upper e s r
-  have hupper1 := hupper.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hupper1
-  have hupper2 := hupper.2
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hupper2
-  suffices SmtLibSemantics.IsLawfulLower (-r) (- (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s)) by
-    apply eq_of_IsLawfulLower_of_IsLawfulLower
+  rw [smtLibLower_eq_lower e s he hs]
+  · rw [smtLibUpper_eq_upper e s he hs]
+    · simp [upper]
     · simp [hr]
-    · simp [hr]
-    · apply hlower
-    · apply this
-  constructor
-  · -- TODO: need a theorem that says that 'embed_neg_eq_neg_embed'
-    simp only [embed_neg_eq_neg_embed, SmtLibSemantics.smtLibV_embed_eq,
-      PackedFloat.toExtRat_eq_toExtRat', ExtRat.ge_eq_le_symm]
-    grind only [= ExtRat.le_neg_iff_le_neg, = ExtRat.neg_neg]
-  · intros low' hlow'
-    refine PackedFloat.le_neg_iff_le_neg.mp ?_
-    apply hupper2
-    simp at hlow'
-    apply ExtRat.le_iff_neg_le_neg.mpr
-    simp
-    grind only
+  · simp [hr]
 
 -- upper(-x) = - lower x
 @[simp]
-theorem upper_neg_eq_neg_lower {e s : Nat} (r : ExtRat) (hr : r ≠ .NaN) :
+theorem upper_neg_eq_neg_lower {e s : Nat} (r : ExtRat) (hr : r ≠ .NaN) (he : 0 < e )(hs : 0 < s) :
     (SmtLibSemantics.smtLibUpper.upper (-r) : PackedFloat e s) = - (SmtLibSemantics.smtLibLower.lower r) := by
-  have hupper := isLawfulUpper_upper e s (-r)
-  have hupper1 := hupper.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hupper1
-  have hupper2 := hupper.2
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hupper2
-
-  have hlower := isLawfulLower_lower e s r
-  have hlower1 := hlower.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hlower1
-  have hlower2 := hlower.2
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hlower2
-  suffices SmtLibSemantics.IsLawfulUpper (-r) (- (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s)) by
-    apply eq_of_IsLawfulUpper_of_IsLawfulUpper
-    · simp [ExtRat.neg_eq_NaN_iff, hr]
+  rw [smtLibUpper_eq_upper e s he hs]
+  · rw [smtLibLower_eq_lower e s he hs]
+    · simp [upper]
     · simp [hr]
-    · apply hupper
-    · apply this
-  constructor
-  · simp only [embed_neg_eq_neg_embed, SmtLibSemantics.smtLibV_embed_eq,
-      PackedFloat.toExtRat_eq_toExtRat', ExtRat.ge_eq_le_symm]
-    grind only [= ExtRat.neg_le_iff_neg_le, = ExtRat.neg_neg]
-  · intros up' hup'
-    refine PackedFloat.neg_le_iff_neg_le.mp ?_
-    apply hlower2
-    simp at hup'
-    apply ExtRat.le_iff_neg_le_neg.mpr
-    simp
-    grind only
+  · simp [hr]
 
 /--
 This tells us that `PackedFloat`s are perfectly approximated,
@@ -1222,32 +1184,37 @@ theorem lower_eq_self_of_eq_toExtRat_of_not_isNaN
   (hzero : ¬ x.isZero)
   (h : x.toExtRat = r) :
   (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s) = x := by
-  have hlower := isLawfulLower_lower e s r
-  have hlower1 := hlower.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hlower1
+  rw [smtLibLower_eq_lower e s he hs]
+  · -- show that 'lower' when called on an element of the lower list
+    -- will just produce that number.
+    sorry
+  · sorry
+  -- have hlower := isLawfulLower_lower e s r
+  -- have hlower1 := hlower.1
+  -- simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+  --   ExtRat.ge_eq_le_symm] at hlower1
 
-  have hlower2 := hlower.2
-  subst h
-  specialize (hlower2 x)
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ExtRat.le_refl, forall_const] at hlower2
-  simp only [PackedFloat.toExtRat_eq_toExtRat']
-  have : SmtLibSemantics.smtLibLower.lower x.toExtRat' ≤ x := by
-    apply PackedFloat.le_of_toExtRat'_le_toExtRat'
-    · grind only
-    · grind only
-    · simp
-      grind only [PackedFloat.le_iff_eq_of_isNaN']
-    · simp
-      grind only
-    · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower1
-      intros hxzero hlowrzero hxsign
-      grind only
-    · grind only
-    · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower hlower1 ⊢
-      grind only
-  grind only [PackedFloat.le_antisymm_of_ne_NaN, PackedFloat.le_iff_eq_of_isNaN']
+  -- have hlower2 := hlower.2
+  -- subst h
+  -- specialize (hlower2 x)
+  -- simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+  --   ExtRat.ExtRat.le_refl, forall_const] at hlower2
+  -- simp only [PackedFloat.toExtRat_eq_toExtRat']
+  -- have : SmtLibSemantics.smtLibLower.lower x.toExtRat' ≤ x := by
+  --   apply PackedFloat.le_of_toExtRat'_le_toExtRat'
+  --   · grind only
+  --   · grind only
+  --   · simp
+  --     grind only [PackedFloat.le_iff_eq_of_isNaN']
+  --   · simp
+  --     grind only
+  --   · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower1
+  --     intros hxzero hlowrzero hxsign
+  --     grind only
+  --   · grind only
+  --   · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower hlower1 ⊢
+  --     grind only
+  -- grind only [PackedFloat.le_antisymm_of_ne_NaN, PackedFloat.le_iff_eq_of_isNaN']
 
   /--
 info: 'Fp.lower_eq_self_of_eq_toExtRat_of_not_isNaN' depends on axioms: [propext,

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1612,6 +1612,7 @@ gives us the location of the guard bit inside the unpaked float.
 sorry
 -/
 theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
+    -- TODO: I need a bound on `x.ex` to be at most `maxNormalExp` I guess.
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
     -- (heusu : eu ≤ su)
@@ -1636,11 +1637,13 @@ theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
       rw [Int.sub_toNat_eq_zero_of_le]
       · simp
         rw [Nat.mod_eq_of_lt]
-        · sorry
+        · have : su < 2 ^ su := by exact Nat.lt_two_pow_self
+          grind only
       · grind only
     case isFalse h =>
       simp at h
       rw [Nat.mod_eq_of_lt]
+      have : su < 2 ^ su := by exact Nat.lt_two_pow_self
       sorry
   · grind only
   · sorry

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1580,6 +1580,28 @@ theorem BitVec.allOnes_and_eq_self (bv : BitVec n) :
   ext i hi
   simp
 
+/--
+Zero extension to a larger width does not change the value.
+-/
+theorem BitVec.toNat_zeroExtend_of_le {n m : Nat} (bv : BitVec n) (h : n ≤ m) :
+    (bv.zeroExtend m).toNat = bv.toNat := by
+  rw [BitVec.zeroExtend_eq_setWidth, BitVec.toNat_setWidth_of_le]
+  grind only
+
+/--
+Zero extension to a smaller width does not change the value
+if the value fits in the smaller size.
+-/
+theorem BitVec.toNat_zeroExtend_of_lt {n m : Nat} (bv : BitVec n) (h : bv.toNat  < 2 ^ m) :
+    (bv.zeroExtend m).toNat = bv.toNat := by
+  rw [BitVec.zeroExtend_eq_setWidth]
+  simp only [BitVec.toNat_setWidth]
+  rw [Nat.mod_eq_of_lt]
+  grind only
+
+
+
+
 theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1486,126 +1486,6 @@ theorem UnpackedFloat.clearSignificand_toRat_le_of_nonneg (uf : UnpackedFloat e 
   simp only [PackedFloat.Rat.natCast_le_natCast_iff_le]
   grind only
 
-
-
-/-- For a nonnegative unpacked float, the error from clearing guard/sticky bits is bounded by
-    2^(guardBitIdx + 1) ULPs at the significand level, i.e.,
-    `x.toRat - cleared.toRat < 2^(guardBitIdx + 1) * 2^(x.toExpInt)`.
-    This is the ULP of the target precision. -/
-theorem clearSignificand_toRat_sub_lt (uf : UnpackedFloat e s)
-    (targetExponentWidth targetSignificandWidth : Nat)
-    (h : 0 ≤ uf.toRat) :
-    uf.toRat - (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat <
-      (2 : Rat) ^ ((uf.guardBitIndex targetExponentWidth targetSignificandWidth).toNat + 1) *
-      (2 : Rat) ^ uf.toExpInt := by
-  sorry
-
-/--
-The result of 'clearSignificand' results in an unpacked float
-that can be represented in the target format, and has the same rational value as some `PackedFloat`.
--/
-theorem exists_packedFloat_toRat_eq_clearSignificand_toRat (uf : UnpackedFloat e s)
-    (targetExponentWidth targetSignificandWidth : Nat) :
-    ∃ (pf : PackedFloat targetExponentWidth targetSignificandWidth),
-      pf.toRat = (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat := by
-  sorry
-
-
-
-theorem toExtRat_ufCleared_eq_lower_of_nonneg (x : UnpackedFloat e s)
-    (hx : 0 ≤ x.toRat) :
-    (ExtRat.Number (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat) =
-    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
-      := by
-  sorry
-
-theorem toExtRat_ufCleared_eq_upper_of_neg (x : UnpackedFloat e s)
-    (hx : x.toRat < 0 ) :
-    (ExtRat.Number (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat) =
-    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
-      := by
-  sorry
-
-theorem toExtRat_successorAwayFromZero_eq_lower_of_neg (x : UnpackedFloat e s)
-    (hx : x.toRat < 0) :
-    (ExtRat.Number (x.successorAwayFromZero targetExponentWidth targetSignificandWidth).toRat) =
-    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
-      := by
-  sorry
-
-
-@[simp]
-theorem UnpackedFloat.extractIsEven_eq_isEven_lower_of_nonneg (x : UnpackedFloat e s)
-    (hx : x.sign = false) :
-    x.extractIsEven e s = (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).isEven
-          (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat)) := by
-  simp [UnpackedFloat.extractIsEven]
-  simp [SmtLibSemantics.smtLibRoundMethod]
-  sorry
-
-@[simp]
-theorem UnpackedFloat.extractIsEven_eq_isEven_upper_of_neg (x : UnpackedFloat e s)
-    (hx : x.sign = true) :
-    x.extractIsEven e s = (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).isEven
-          (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat)) := by
-  simp [UnpackedFloat.extractIsEven]
-  simp [SmtLibSemantics.smtLibRoundMethod]
-  sorry
-
-@[simp]
-theorem UnpackedFloat.extractGuardBit_eq_not_lowerHalf_of_nonneg (x : UnpackedFloat e s)
-    (hx : x.sign = false) :
-    x.extractGuardBit e s = ! (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).lowerHalf (ExtRat.Number x.toRat) := by
-  simp [UnpackedFloat.extractGuardBit]
-  simp [SmtLibSemantics.smtLibRoundMethod]
-  sorry
-
-@[simp]
-theorem UnpackedFloat.extractGuardBit_eq_lowerHalf_of_neg (x : UnpackedFloat e s)
-    (hx : x.sign = true) :
-    x.extractGuardBit e s = (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).lowerHalf (ExtRat.Number x.toRat) := by
-  simp [UnpackedFloat.extractGuardBit]
-  simp [SmtLibSemantics.smtLibRoundMethod]
-  sorry
-
-@[simp]
-theorem BitVec.and_allOnes_eq_self (bv : BitVec n) :
-    bv &&& (BitVec.allOnes n) = bv := by
-  ext i hi
-  simp
-
-@[simp]
-theorem BitVec.allOnes_and_eq_self (bv : BitVec n) :
-    (BitVec.allOnes n) &&& bv = bv := by
-  ext i hi
-  simp
-
-/--
-Zero extension to a larger width does not change the value.
--/
-theorem BitVec.toNat_zeroExtend_of_le {n m : Nat} (bv : BitVec n) (h : n ≤ m) :
-    (bv.zeroExtend m).toNat = bv.toNat := by
-  rw [BitVec.zeroExtend_eq_setWidth, BitVec.toNat_setWidth_of_le]
-  grind only
-
-/--
-Zero extension to a smaller width does not change the value
-if the value fits in the smaller size.
--/
-theorem BitVec.toNat_zeroExtend_of_lt {n m : Nat} (bv : BitVec n) (h : bv.toNat  < 2 ^ m) :
-    (bv.zeroExtend m).toNat = bv.toNat := by
-  rw [BitVec.zeroExtend_eq_setWidth]
-  simp only [BitVec.toNat_setWidth]
-  rw [Nat.mod_eq_of_lt]
-  grind only
-
-@[simp]
-theorem Int.sub_toNat_eq_zero_of_le {a b : Int} (h : a ≤ b) :
-    (a - b).toNat = 0 := by
-  simp
-  grind only
-
-
 /--
 The guard bit index when interpreted as a natural number
 gives us the location of the guard bit inside the unpaked float.
@@ -1676,6 +1556,156 @@ theorem BitVec.eq_iff_getLsbD_eq (a b : BitVec w) : a = b ↔
 theorem iff_iff_not_iff_not {p q : Prop} :
     (p ↔ q) ↔ (¬ p ↔ ¬ q) := by
   grind
+
+
+/-- For a nonnegative unpacked float, the error from clearing guard/sticky bits is bounded by
+    2^(guardBitIdx + 1) ULPs at the significand level, i.e.,
+    `x.toRat - cleared.toRat < 2^(guardBitIdx + 1) * 2^(x.toExpInt)`.
+    This is the ULP of the target precision. -/
+theorem clearSignificand_toRat_sub_lt (uf : UnpackedFloat e s)
+    (targetExponentWidth targetSignificandWidth : Nat)
+    (h : 0 ≤ uf.toRat) :
+    uf.toRat - (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat <
+      (2 : Rat) ^ ((uf.guardBitIndex targetExponentWidth targetSignificandWidth).toNat + 1) *
+      (2 : Rat) ^ uf.toExpInt := by
+  sorry
+
+/--
+The result of 'clearSignificand' results in an unpacked float
+that can be represented in the target format, and has the same rational value as some `PackedFloat`.
+-/
+theorem exists_packedFloat_toRat_eq_clearSignificand_toRat (uf : UnpackedFloat e s)
+    (targetExponentWidth targetSignificandWidth : Nat) :
+    ∃ (pf : PackedFloat targetExponentWidth targetSignificandWidth),
+      pf.toRat = (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat := by
+  sorry
+
+
+
+theorem toExtRat_ufCleared_eq_lower_of_nonneg (x : UnpackedFloat e s)
+    (hx : 0 ≤ x.toRat) :
+    (ExtRat.Number (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat) =
+    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
+      := by
+  sorry
+
+theorem toExtRat_ufCleared_eq_upper_of_neg (x : UnpackedFloat e s)
+    (hx : x.toRat < 0 ) :
+    (ExtRat.Number (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat) =
+    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
+      := by
+  sorry
+
+theorem toExtRat_successorAwayFromZero_eq_lower_of_neg (x : UnpackedFloat e s)
+    (hx : x.toRat < 0) :
+    (ExtRat.Number (x.successorAwayFromZero targetExponentWidth targetSignificandWidth).toRat) =
+    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
+      := by
+  sorry
+
+
+@[simp]
+theorem UnpackedFloat.extractIsEven_eq_isEven_lower_of_nonneg (x : UnpackedFloat e s)
+    (hx : x.sign = false) :
+    x.extractIsEven e s = (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).isEven
+          (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat)) := by
+  simp [UnpackedFloat.extractIsEven]
+  simp [SmtLibSemantics.smtLibRoundMethod]
+  sorry
+
+@[simp]
+theorem UnpackedFloat.extractIsEven_eq_isEven_upper_of_neg (x : UnpackedFloat e s)
+    (hx : x.sign = true) :
+    x.extractIsEven e s = (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).isEven
+          (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat)) := by
+  simp [UnpackedFloat.extractIsEven]
+  simp [SmtLibSemantics.smtLibRoundMethod]
+  sorry
+
+
+theorem extractGuardBit_eq_true_iff
+    (hep : 1 < ep) (hsp : 0 < sp)
+    (heu : exponentWidth ep sp ≤ eu)
+    (hsu : sp + 2 ≤ su)
+    (x : UnpackedFloat eu su) :
+    x.extractGuardBit ep sp = true ↔ x.sig.getLsbD (su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat) := by
+  simp [UnpackedFloat.extractGuardBit]
+  constructor
+  · intros h
+    obtain h := BitVec.ne_iff_getLsbD_ne .. |>.mp h
+    obtain ⟨i, hi⟩ := h
+    simp at hi
+    rw [UnpackedFloat.toNat_guardBitIndex_eq hep hsp heu hsu] at hi
+    grind only
+  · intros h
+    intros hcontra
+    obtain hcontra := BitVec.eq_iff_getLsbD_eq .. |>.mp hcontra
+    simp at hcontra
+    specialize hcontra _ h (by grind)
+    rw [UnpackedFloat.toNat_guardBitIndex_eq hep hsp heu hsu] at hcontra
+    grind only
+
+/--
+The guard bit is the bit at the lower index at '2' (when `su = sp + 2`),
+plus the offset from the exponent difference, which accounts for shifts when we are subnormal.
+-/
+theorem extractGuardBit_eq_getLsbD
+    (hep : 1 < ep) (hsp : 0 < sp)
+    (heu : exponentWidth ep sp ≤ eu)
+    (hsu : sp + 2 ≤ su)
+    (x : UnpackedFloat eu su) :
+    x.extractGuardBit ep sp =  x.sig.getLsbD (su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat)  := by
+  have := extractGuardBit_eq_true_iff hep hsp heu hsu x
+  grind only [#0e2e4e0bb1f1e395]
+
+
+@[simp]
+theorem UnpackedFloat.extractGuardBit_eq_not_lowerHalf_of_nonneg (x : UnpackedFloat e s)
+    (hx : x.sign = false) :
+    x.extractGuardBit e s = ! (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).lowerHalf (ExtRat.Number x.toRat) := by
+  simp [SmtLibSemantics.smtLibRoundMethod]
+  sorry
+
+@[simp]
+theorem UnpackedFloat.extractGuardBit_eq_lowerHalf_of_neg (x : UnpackedFloat e s)
+    (hx : x.sign = true) :
+    x.extractGuardBit e s = (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).lowerHalf (ExtRat.Number x.toRat) := by
+  simp [UnpackedFloat.extractGuardBit]
+  simp [SmtLibSemantics.smtLibRoundMethod]
+  sorry
+
+@[simp]
+theorem BitVec.and_allOnes_eq_self (bv : BitVec n) :
+    bv &&& (BitVec.allOnes n) = bv := by
+  ext i hi
+  simp
+
+@[simp]
+theorem BitVec.allOnes_and_eq_self (bv : BitVec n) :
+    (BitVec.allOnes n) &&& bv = bv := by
+  ext i hi
+  simp
+
+/--
+Zero extension to a larger width does not change the value.
+-/
+theorem BitVec.toNat_zeroExtend_of_le {n m : Nat} (bv : BitVec n) (h : n ≤ m) :
+    (bv.zeroExtend m).toNat = bv.toNat := by
+  rw [BitVec.zeroExtend_eq_setWidth, BitVec.toNat_setWidth_of_le]
+  grind only
+
+/--
+Zero extension to a smaller width does not change the value
+if the value fits in the smaller size.
+-/
+theorem BitVec.toNat_zeroExtend_of_lt {n m : Nat} (bv : BitVec n) (h : bv.toNat  < 2 ^ m) :
+    (bv.zeroExtend m).toNat = bv.toNat := by
+  rw [BitVec.zeroExtend_eq_setWidth]
+  simp only [BitVec.toNat_setWidth]
+  rw [Nat.mod_eq_of_lt]
+  grind only
+
+
 
 theorem extractStickyBit_eq_true_iff
   (hep : 1 < ep) (hsp : 0 < sp)

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1073,7 +1073,8 @@ theorem eq_upper_of_IsLawfulUpper (e s : Nat) (he : 0 < e) (hs : 0 < s)
   · apply Classical.byContradiction
     intros hcontra
     apply hrnan
-    grind [ExtRat, upper]
+    simp at hcontra
+    sorry
   · apply hupper
   · exact IsLawfulUpper_upper e s he hs r
 

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1612,7 +1612,8 @@ gives us the location of the guard bit inside the unpaked float.
 sorry
 -/
 theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
-    -- TODO: I need a bound on `x.ex` to be at most `maxNormalExp` I guess.
+    -- TODO: I need a bound on `x.ex` to be at most `maxNormalExp`.
+    -- TODO: I need a bound on `x.ex` to be at least `minSubnormalExp`.
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
     -- (heusu : eu ≤ su)
@@ -1646,8 +1647,16 @@ theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
       have : su < 2 ^ su := by exact Nat.lt_two_pow_self
       sorry
   · grind only
-  · sorry
-  · sorry
+  · have := neg_two_pow_le_minNormalExp hep hsp heu
+    rw [toInt_ofInt_minNormalExp_eq_minNormalExp_of_le hep hsp heu]
+    -- | This needs bounds on `minSubnormalExp ≤ x.ex.toInt` to prove this.
+    -- ⊢ -2 ^ (eu - 1) ≤ minNormalExp ep - x.ex.toInt
+    sorry
+  · have := minNormalExp_lt_two_pow hep hsp heu
+    rw [toInt_ofInt_minNormalExp_eq_minNormalExp_of_le hep hsp heu]
+    --  This needs bounds on `x.ex.toInt ≤ maxNormalExp` to prove this.
+    -- ⊢ minNormalExp ep - x.ex.toInt < 2 ^ (eu - 1)
+    sorry
 
 theorem BitVec.eq_iff_getLsbD_eq (a b : BitVec w) : a = b ↔
     (∀ (i : Nat), a.getLsbD i = b.getLsbD i) := by

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1569,13 +1569,58 @@ theorem UnpackedFloat.extractGuardBit_eq_lowerHalf_of_neg (x : UnpackedFloat e s
   sorry
 
 @[simp]
+theorem BitVec.and_allOnes_eq_self (bv : BitVec n) :
+    bv &&& (BitVec.allOnes n) = bv := by
+  ext i hi
+  simp
+
+@[simp]
+theorem BitVec.allOnes_and_eq_self (bv : BitVec n) :
+    (BitVec.allOnes n) &&& bv = bv := by
+  ext i hi
+  simp
+
+theorem UnpackedFloat.toNat_guardBitIndex_eq (hep : 1 < ep) (hsp : 0 < sp)
+    (heu : exponentWidth ep sp ≤ eu)
+    (hsu : sp + 2 ≤ su)
+    (heusu : eu ≤ su)
+    (x : UnpackedFloat eu su) :
+    (x.guardBitIndex ep sp).toNat = 1 := by
+  rw [UnpackedFloat.guardBitIndex]
+  split
+  case isTrue h =>
+    rw [BitVec.slt_eq_decide] at h
+    simp only [decide_eq_true_eq] at h
+    rw [toInt_ofInt_minNormalExp_eq_minNormalExp_of_le (e := ep) (s := sp) (w := eu)
+      (by grind only) (by grind only)] at h
+    rw [show su - 1  - (sp + 1) = su - (sp + 2) by grind only]
+    rw [BitVec.zeroExtend_eq_setWidth]
+    rw [BitVec.toNat_add_of_lt]
+    · rw [BitVec.toNat_setWidth_of_le]
+      · sorry
+      · exact heusu
+    · sorry
+    · sorry
+  case isFalse h =>
+    sorry
+
+theorem extractStickyBit_eq_false_iff (x : UnpackedFloat e s) :
+  x.extractStickyBit e s = false ↔
+      ∀ (i : Nat), x.sig.getLsbD i = 0 := by
+  simp [UnpackedFloat.extractStickyBit]
+
+
+@[simp]
 theorem UnpackedFloat.extractStickyBit_eq_not_tieBreak_of_nonneg_of_guardBit (x : UnpackedFloat e s)
     (hx : x.sign = false)
     (hguard : x.extractGuardBit e s = true) :
     x.extractStickyBit e s = ! (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).tieBreak (ExtRat.Number x.toRat) := by
   simp [UnpackedFloat.extractStickyBit]
   simp [SmtLibSemantics.smtLibRoundMethod]
-  sorry
+  constructor
+  · intros h
+    sorry
+  · sorry
 
 
 

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -67,6 +67,8 @@ theorem isLawfulLower_NaN_iff_isNaN (x : PackedFloat e s) :
   intros lower hlower
   simp [hx, hlower]
 
+
+
 @[elab_as_elim]
 theorem Classical.epsilon_elim {α : Sort u} {p q : α → Prop} (y : α) (hy : p y)
    (hpq : ∀ x, p x → q x) :
@@ -107,6 +109,7 @@ theorem isNaN_lower_NaN (e s : Nat) :
   · simp
   · intros x hx
     simp [hx]
+
 
 @[simp]
 theorem roundRNA_mkNaN (eout sout : Nat) (sign : Bool) :
@@ -572,6 +575,29 @@ theorem EquivUptoNaN.of_mkNaN_iff (x : PackedFloat e s) : EquivUptoNaN x (Packed
   simp [EquivUptoNaN]
   grind only [!PackedFloat.isNaN_mkNaN]
 
+@[simp]
+theorem isNaN_smtLibLower_iff_eq_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat):
+    (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s).isNaN ↔ r = .NaN := by
+  constructor
+  · intros hpf
+    rcases r with rfl | sign | num
+    · simp
+    · have := lower_infinity_eq_getInfinity sign he hs
+      rw [this] at hpf
+      simp at hpf
+      grind only
+    · sorry
+  · simp [SmtLibSemantics.smtLibLower]
+    intros h
+    apply Classical.epsilon_elim (q := fun (x : PackedFloat e s) => x.isNaN) (y := PackedFloat.getNaN e s)
+    · subst h
+      exact isLawfulLower_of_isNaN
+    · subst h
+      intros pf hcontra
+      exact (isLawfulLower_NaN_iff_isNaN pf).mp hcontra
+
+
+
 section ComputableLowerUpper
 
 open SmtLibSemantics
@@ -756,6 +782,13 @@ def maxPackedFloatNonNaN
               · grind only [usr Subtype.property, = PackedFloat.isNaN_iff_toExtRat'_eq_NaN]
 ⟩
 
+@[simp]
+theorem not_isNaN_maxPackedFloatNaN (xs : List (PackedFloat e s))
+    (hxs : ∀ x ∈ xs, ¬ x.isNaN) (he : 0 < e) (hs : 0 < s) :
+    ¬ (maxPackedFloatNonNaN xs hxs he hs).val.isNaN := by
+  have := (maxPackedFloatNonNaN xs hxs he hs).property
+  simp [this]
+
 /--
 the result of 'maxPackedFloatNonNaN' is actually in the list when the list is nonempty.
 -/
@@ -852,6 +885,28 @@ else
   let max := maxPackedFloatNonNaN arr.val (by simp; grind only [#1a7c]) he hs
   max.val
 
+
+/--
+The result of 'lower' is NaN iff the input is NaN.
+-/
+theorem isNaN_lower_iff_eq_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat):
+    (lower e s he hs r).isNaN ↔ r = .NaN := by
+  simp [lower]
+  split
+  case isTrue h =>
+    simp [h]
+  case isFalse h =>
+    simp [h]
+    by_cases hr : r = ExtRat.Number 0
+    · simp [hr]
+      grind
+    · simp [hr]
+
+
+
+/-- info: 'Fp.isNaN_lower_iff_eq_NaN' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms isNaN_lower_iff_eq_NaN
+
 /--
 the 'lower' function indeed computes a lawful lower bound for every ExtRat.
 This shows that lawful lower bounds exist for all rationals.
@@ -933,6 +988,12 @@ theorem IsLawfulUpper_upper (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) :
   simp [upper]
   apply IsLawfulUpper_iff_IsLawfulLower_neg_neg .. |>.mpr
   simp
+
+@[simp]
+theorem isNaN_upper_iff_eq_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat):
+    (upper e s he hs r).isNaN ↔ r = .NaN := by
+  simp [upper]
+  simp [isNaN_lower_iff_eq_NaN]
 
 /-- info: 'Fp.IsLawfulUpper_upper' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms IsLawfulUpper_upper
@@ -1022,21 +1083,32 @@ theorem eq_lower_of_IsLawfulLower (e s : Nat) (he : 0 < e) (hs : 0 < s)
   · apply hlower
   · exact IsLawfulLower_lower e s he hs r
 
+/--
+info: 'Fp.eq_lower_of_IsLawfulLower' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in #print axioms eq_lower_of_IsLawfulLower
 
 /--
 the value of smtLibLower equals that of 'lower' on all non-NaN rationals.
 -/
+@[simp]
 theorem smtLibLower_eq_lower (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
     SmtLibSemantics.smtLibLower.lower r = lower e s he hs r := by
   apply eq_of_IsLawfulLower_of_IsLawfulLower (r := r)
   · intros hcontra
-    sorry
+    have := eq_lower_of_IsLawfulLower e s he hs r (SmtLibSemantics.smtLibLower.lower r) hr
+    specialize this (by exact lsLawfulLower_smtLibLower e s he hs r)
+    rw [this] at hcontra
+    have := isNaN_lower_iff_eq_NaN e s he hs r
+    grind only
   · intros hcontra
     apply hr
     grind only [→ PackedFloat.not_isZero_of_isNaN, lower, PackedFloat.isZero_getZero, #2962, #90ed]
   · exact lsLawfulLower_smtLibLower e s he hs r
   · exact IsLawfulLower_lower e s he hs r
 
+/-- info: 'Fp.smtLibLower_eq_lower' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms smtLibLower_eq_lower
 
 /-## Upper -/
 
@@ -1093,21 +1165,34 @@ theorem eq_upper_of_IsLawfulUpper (e s : Nat) (he : 0 < e) (hs : 0 < s)
     intros hcontra
     apply hrnan
     simp at hcontra
-    sorry
+    grind only
   · apply hupper
   · exact IsLawfulUpper_upper e s he hs r
 
+/--
+info: 'Fp.eq_upper_of_IsLawfulUpper' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in #print axioms eq_upper_of_IsLawfulUpper
+
+@[simp]
 theorem smtLibUpper_eq_upper (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
     SmtLibSemantics.smtLibUpper.upper r = upper e s he hs r := by
   apply eq_of_IsLawfulUpper_of_IsLawfulUpper (r := r)
   · intros hcontra
-    sorry
+    have := eq_upper_of_IsLawfulUpper e s he hs r (SmtLibSemantics.smtLibUpper.upper r) hr
+    rw [this] at hcontra
+    · have := isNaN_upper_iff_eq_NaN e s he hs r
+      grind only
+    · exact isLawfulUpper_smtLibUpper e s he hs r
   · intros hcontra
     apply hr
-    sorry
+    have := isNaN_upper_iff_eq_NaN e s he hs r
+    grind only
   · exact isLawfulUpper_smtLibUpper e s he hs r
   · exact IsLawfulUpper_upper e s he hs r
 
+/-- info: 'Fp.smtLibUpper_eq_upper' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms smtLibUpper_eq_upper
 
 
 @[simp]
@@ -1115,6 +1200,11 @@ theorem not_isNaN_lower_of_ne_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : Ext
     (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s).isNaN = false := by
   rw [smtLibLower_eq_lower e s he hs r hr]
   grind only [lower, → PackedFloat.not_isZero_of_isNaN, PackedFloat.isZero_getZero, #2962, #90ed]
+
+/--
+info: 'Fp.not_isNaN_lower_of_ne_NaN' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in #print axioms not_isNaN_lower_of_ne_NaN
 
 @[simp]
 theorem not_isNaN_lower_neg_of_ne_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
@@ -1125,26 +1215,30 @@ theorem not_isNaN_lower_neg_of_ne_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r :
 
 
 @[simp]
-theorem not_isNaN_upper_of_ne_NaN (e s : Nat) (r : ExtRat) (hr : r ≠ .NaN) :
+theorem not_isNaN_upper_of_ne_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
     (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s).isNaN = false := by
   by_cases hnan : (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s).isNaN
   · exfalso
-    have hembed := self_le_embed_upper (e := e) (s := s) r
-    simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat'] at hembed
-    rw [PackedFloat.toExtRat'_eq_NaN_of_isNaN _ hnan] at hembed
-    simp at hembed
+    rw [smtLibUpper_eq_upper e s he hs r hr] at hnan
+    have := isNaN_upper_iff_eq_NaN e s he hs r
     grind only
   · simp [hnan]
 
-theorem isLawfulUpper_upper (e s : Nat) (r : ExtRat) :
+/--
+info: 'Fp.not_isNaN_upper_of_ne_NaN' depends on axioms: [propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in #print axioms not_isNaN_upper_of_ne_NaN
+
+theorem isLawfulUpper_upper (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) :
     SmtLibSemantics.IsLawfulUpper r (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s) := by
-  constructor
-  · apply self_le_embed_upper <;> grind only
-  · intros upper' hupper'
-    apply le_upper_of_self_le_embed <;> grind only
+  by_cases hr : r = .NaN
+  · simp [hr]
+  · have := smtLibUpper_eq_upper e s he hs r hr
+    rw [this]
+    exact IsLawfulUpper_upper e s he hs r
 
-
-
+/-- info: 'Fp.IsLawfulUpper_upper' depends on axioms: [propext, Classical.choice, Quot.sound] -/
+#guard_msgs in #print axioms IsLawfulUpper_upper
 
 
 @[simp]
@@ -1154,7 +1248,7 @@ theorem embed_neg_eq_neg_embed {e s : Nat} (x : PackedFloat e s) :
 
 -- lower(-x) = - upper x
 @[simp]
-theorem lower_neg_eq_neg_upper {e s : Nat} (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
+theorem smtLibLower_neg_eq_neg_smtLibUpper {e s : Nat} (he : 0 < e) (hs : 0 < s) (r : ExtRat) (hr : r ≠ .NaN) :
     (SmtLibSemantics.smtLibLower.lower (-r) : PackedFloat e s) = - (SmtLibSemantics.smtLibUpper.upper r) := by
   rw [smtLibLower_eq_lower e s he hs]
   · rw [smtLibUpper_eq_upper e s he hs]
@@ -1164,7 +1258,7 @@ theorem lower_neg_eq_neg_upper {e s : Nat} (he : 0 < e) (hs : 0 < s) (r : ExtRat
 
 -- upper(-x) = - lower x
 @[simp]
-theorem upper_neg_eq_neg_lower {e s : Nat} (r : ExtRat) (hr : r ≠ .NaN) (he : 0 < e )(hs : 0 < s) :
+theorem smtLibUpper_neg_eq_neg_smtLibLower {e s : Nat} (r : ExtRat) (hr : r ≠ .NaN) (he : 0 < e )(hs : 0 < s) :
     (SmtLibSemantics.smtLibUpper.upper (-r) : PackedFloat e s) = - (SmtLibSemantics.smtLibLower.lower r) := by
   rw [smtLibUpper_eq_upper e s he hs]
   · rw [smtLibLower_eq_lower e s he hs]
@@ -1177,99 +1271,74 @@ This tells us that `PackedFloat`s are perfectly approximated,
 and that calling `lower` on a rational that represents a `PackedFloat`
 gives us the same `PackedFloat` back, as long as it's not NaN.
 -/
-theorem lower_eq_self_of_eq_toExtRat_of_not_isNaN
+theorem smtLibLower_eq_self_of_eq_toExtRat_of_not_isNaN
   (he : 0 < e) (hs : 0 < s)
   (x : PackedFloat e s) (r : ExtRat)
   (hnum : ¬ x.isNaN)
   (hzero : ¬ x.isZero)
   (h : x.toExtRat = r) :
   (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s) = x := by
-  rw [smtLibLower_eq_lower e s he hs]
-  · -- show that 'lower' when called on an element of the lower list
-    -- will just produce that number.
-    sorry
-  · sorry
-  -- have hlower := isLawfulLower_lower e s r
-  -- have hlower1 := hlower.1
-  -- simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-  --   ExtRat.ge_eq_le_symm] at hlower1
+  have hlower := lsLawfulLower_smtLibLower e s he hs r
+  have hlower1 := hlower.1
+  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+    ExtRat.ge_eq_le_symm] at hlower1
 
-  -- have hlower2 := hlower.2
-  -- subst h
-  -- specialize (hlower2 x)
-  -- simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-  --   ExtRat.ExtRat.le_refl, forall_const] at hlower2
-  -- simp only [PackedFloat.toExtRat_eq_toExtRat']
-  -- have : SmtLibSemantics.smtLibLower.lower x.toExtRat' ≤ x := by
-  --   apply PackedFloat.le_of_toExtRat'_le_toExtRat'
-  --   · grind only
-  --   · grind only
-  --   · simp
-  --     grind only [PackedFloat.le_iff_eq_of_isNaN']
-  --   · simp
-  --     grind only
-  --   · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower1
-  --     intros hxzero hlowrzero hxsign
-  --     grind only
-  --   · grind only
-  --   · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower hlower1 ⊢
-  --     grind only
-  -- grind only [PackedFloat.le_antisymm_of_ne_NaN, PackedFloat.le_iff_eq_of_isNaN']
+  have hlower2 := hlower.2
+  subst h
+  specialize (hlower2 x)
+  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+    ExtRat.ExtRat.le_refl, forall_const] at hlower2
+  simp only [PackedFloat.toExtRat_eq_toExtRat']
+  have : SmtLibSemantics.smtLibLower.lower x.toExtRat' ≤ x := by
+    apply PackedFloat.le_of_toExtRat'_le_toExtRat'
+    · grind only
+    · grind only
+    · simp
+      grind only [PackedFloat.le_iff_eq_of_isNaN']
+    · simp
+      grind only
+    · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower1
+      intros hxzero hlowrzero hxsign
+      grind only
+    · grind only
+    · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hlower hlower1 ⊢
+      grind only
+  grind only [PackedFloat.le_antisymm_of_ne_NaN, PackedFloat.le_iff_eq_of_isNaN']
 
   /--
-info: 'Fp.lower_eq_self_of_eq_toExtRat_of_not_isNaN' depends on axioms: [propext,
- Classical.choice,
- Fp.embed_lower_le_self,
- Fp.le_lower_of_embed_le,
- Quot.sound]
+info: 'Fp.smtLibLower_eq_self_of_eq_toExtRat_of_not_isNaN' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
-#guard_msgs in #print axioms lower_eq_self_of_eq_toExtRat_of_not_isNaN
+#guard_msgs in #print axioms smtLibLower_eq_self_of_eq_toExtRat_of_not_isNaN
 
 /--
 upper perfectly approximates PackedFloats, and calling `upper` on a rational that represents a `PackedFloat`
 gives us the same `PackedFloat` back, as long as it's not NaN.
 -/
-theorem upper_eq_self_of_eq_toExtRat_of_not_isNaN
+theorem smtLibUpper_eq_self_of_eq_toExtRat_of_not_isNaN
   (he : 0 < e) (hs : 0 < s)
   (x : PackedFloat e s) (r : ExtRat)
   (hnum : ¬ x.isNaN)
   (hzero : ¬ x.isZero)
   (h : x.toExtRat = r) :
   (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s) = x := by
-  have hupper := isLawfulUpper_upper e s r
-  have hupper1 := hupper.1
-  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
-    ExtRat.ge_eq_le_symm] at hupper1
-  have hupper2 := hupper.2
-  subst h
-  specialize (hupper2 x)
-  simp only [PackedFloat.toExtRat_eq_toExtRat', SmtLibSemantics.smtLibV_embed_eq,
-    ExtRat.ExtRat.le_refl, forall_const] at hupper2
-  have : x ≤ SmtLibSemantics.smtLibUpper.upper x.toExtRat' := by
-    apply PackedFloat.le_of_toExtRat'_le_toExtRat'
-    · simp [he]
-    · simp [hs]
+  rw [show r = - (- r) by grind only [= ExtRat.neg_neg]]
+  rw [smtLibUpper_neg_eq_neg_smtLibLower]
+  · rw [smtLibLower_eq_self_of_eq_toExtRat_of_not_isNaN he hs (- x)]
     · simp
-      grind only [PackedFloat.le_iff_eq_of_isNaN']
-    · simp
-      grind only [PackedFloat.le_iff_eq_of_isNaN]
-    · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hupper1
+    · simp [hnum]
+    · simp [hzero]
+    · simp [he, hs]
+      simp only [PackedFloat.toExtRat_eq_toExtRat'] at h
       grind only
-    · intros hUpperZero hXZero hXSign
-      grind only
-    · simp only [PackedFloat.toExtRat_eq_toExtRat'] at hupper1
-      grind only
-  simp only [PackedFloat.toExtRat_eq_toExtRat']
-  grind only [PackedFloat.le_antisymm_of_ne_NaN, PackedFloat.le_iff_eq_of_isNaN']
+  · simp at h
+    simp; grind only [= PackedFloat.isNaN_iff_toExtRat'_eq_NaN]
+  · simp [he]
+  · simp [hs]
 
 /--
-info: 'Fp.upper_eq_self_of_eq_toExtRat_of_not_isNaN' depends on axioms: [propext,
- Classical.choice,
- Fp.le_upper_of_self_le_embed,
- Fp.self_le_embed_upper,
- Quot.sound]
+info: 'Fp.smtLibUpper_eq_self_of_eq_toExtRat_of_not_isNaN' depends on axioms: [propext, Classical.choice, Quot.sound]
 -/
-#guard_msgs in #print axioms upper_eq_self_of_eq_toExtRat_of_not_isNaN
+#guard_msgs in #print axioms smtLibUpper_eq_self_of_eq_toExtRat_of_not_isNaN
 
 -- /--
 -- The abstract version of 'shouldRoundUp' that only depends on the rounding mode and the bits,
@@ -1848,18 +1917,25 @@ theorem UnpackedFloat.extractStickyBit_eq_not_tieBreak_of_nonneg_of_guardBit
   · grind only
   · grind only
 
-
-theorem UnpackedFloat.toExtRat_round
+/--
+The final theorem: That our implementation of 'round' matches the SMT-LIB
+definition of rounding. But this should be defined carefully.
+-/
+theorem UnpackedFloat.toExtRat_round_eq_smtLibRound
     (he : 1 < ep)
     (hs : 0 < sp)
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
-    (x : UnpackedFloat eu su) :
+    (x : UnpackedFloat eu su)
+    (rstar : Rat) -- rational number we are modelling.
+    (hx : (rstar - hx).abs < (2 : Rat) ^ (-((sp + 1) : Int))) -- the rational is within 0.5 ulp of the unpacked float.
+    -- | The sticky bitt tracks whether 'r' is exactly representable.
+    -- (hsticky : (∃ (pf : PackedFloat ep sp), pf.toRat = rstar)  x.extractStickyBit ep sp = false)
+      :
     (x.round rm (tep := ep) (tsp := sp) : EUnpackedFloat (exponentWidth ep sp) (sp + 1)).toExtRat =
     ((SmtLibSemantics.smtLibRoundMethod (R := ExtRat) ep sp SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).round rm x.sign (ExtRat.Number x.toRat)).toExtRat := by
   simp
   rw [UnpackedFloat.round]
-
   sorry
 
 end Fp

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1433,25 +1433,60 @@ theorem clearSignificand_ex (uf : UnpackedFloat e s)
   simp [UnpackedFloat.clearSignificand]
 
 /-- Clearing guard/sticky bits can only decrease the significand value. -/
-theorem clearSignificand_sig_toNat_le (uf : UnpackedFloat e s)
+theorem UnpackedFloat.clearSignificand_sig_toNat_le (uf : UnpackedFloat e s)
     (targetExponentWidth targetSignificandWidth : Nat) :
     (uf.clearSignificand targetExponentWidth targetSignificandWidth).sig.toNat ≤ uf.sig.toNat := by
-  sorry
+  rw [UnpackedFloat.clearSignificand]
+  simp only [BitVec.toNat_and]
+  grind only [Nat.and_le_left]
+
+
 
 /-- For a nonnegative unpacked float, clearing guard/sticky bits yields a nonnegative result. -/
-theorem clearSignificand_toRat_nonneg_of_nonneg (uf : UnpackedFloat e s)
+theorem UnpackedFloat.clearSignificand_toRat_nonneg_of_sign_eq_false (uf : UnpackedFloat e s)
     (targetExponentWidth targetSignificandWidth : Nat)
-    (h : 0 ≤ uf.toRat) :
+    (h : uf.sign = false) :
     0 ≤ (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat := by
-  sorry
+  simp [UnpackedFloat.toRat_eq_toRat']
+  rw [UnpackedFloat.toRat']
+  generalize hcleared : uf.clearSignificand targetExponentWidth targetSignificandWidth = cleared
+  have : 0 < (2 : Rat) ^ cleared.toExpInt := by grind only [Rat.two_pow_pos]
+  have hsign : cleared.sign = false := by
+    simp [← hcleared, UnpackedFloat.clearSignificand, h]
+  simp [hsign]
+  grind only [Rat.mul_nonneg]
+
+
+
 
 /-- For a nonnegative unpacked float, clearing guard/sticky bits rounds toward zero:
     the cleared value is at most the original value. -/
-theorem clearSignificand_toRat_le_of_nonneg (uf : UnpackedFloat e s)
+theorem UnpackedFloat.clearSignificand_toRat_le_of_nonneg (uf : UnpackedFloat e s)
     (targetExponentWidth targetSignificandWidth : Nat)
-    (h : 0 ≤ uf.toRat) :
+    (hufsign : uf.sign = false) :
     (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat ≤ uf.toRat := by
-  sorry
+  simp only [UnpackedFloat.toRat_eq_toRat']
+  rw [UnpackedFloat.toRat' , UnpackedFloat.toRat']
+  generalize hcleared : uf.clearSignificand targetExponentWidth targetSignificandWidth = cleared
+  have hsign : cleared.sign = false := by
+    simp only [← hcleared, UnpackedFloat.clearSignificand, hufsign,
+      BitVec.orderEncode_eq_shiftRight_allOnes]
+  simp [hsign, hufsign]
+  have hexp : cleared.toExpInt = uf.toExpInt := by
+    simp only [UnpackedFloat.toExpInt, ← hcleared, UnpackedFloat.clearSignificand,
+      BitVec.orderEncode_eq_shiftRight_allOnes]
+  simp only [hexp, ge_iff_le]
+  have : cleared.sig.toNat ≤ uf.sig.toNat := by
+    rw [← hcleared]
+    apply UnpackedFloat.clearSignificand_sig_toNat_le
+  suffices (cleared.sig.toNat : Rat) ≤ (uf.sig.toNat : Rat) by
+    apply Rat.mul_le_mul_of_nonneg_right
+    · simp only [PackedFloat.Rat.natCast_le_natCast_iff_le]; grind only
+    · grind only [Rat.le_of_lt, Rat.two_pow_pos]
+  simp only [PackedFloat.Rat.natCast_le_natCast_iff_le]
+  grind only
+
+
 
 /-- For a nonnegative unpacked float, the error from clearing guard/sticky bits is bounded by
     2^(guardBitIdx + 1) ULPs at the significand level, i.e.,

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -575,29 +575,6 @@ theorem EquivUptoNaN.of_mkNaN_iff (x : PackedFloat e s) : EquivUptoNaN x (Packed
   simp [EquivUptoNaN]
   grind only [!PackedFloat.isNaN_mkNaN]
 
-@[simp]
-theorem isNaN_smtLibLower_iff_eq_NaN (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat):
-    (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s).isNaN ↔ r = .NaN := by
-  constructor
-  · intros hpf
-    rcases r with rfl | sign | num
-    · simp
-    · have := lower_infinity_eq_getInfinity sign he hs
-      rw [this] at hpf
-      simp at hpf
-      grind only
-    · sorry
-  · simp [SmtLibSemantics.smtLibLower]
-    intros h
-    apply Classical.epsilon_elim (q := fun (x : PackedFloat e s) => x.isNaN) (y := PackedFloat.getNaN e s)
-    · subst h
-      exact isLawfulLower_of_isNaN
-    · subst h
-      intros pf hcontra
-      exact (isLawfulLower_NaN_iff_isNaN pf).mp hcontra
-
-
-
 section ComputableLowerUpper
 
 open SmtLibSemantics
@@ -1025,6 +1002,9 @@ theorem isEven_upper_eq_not_isEven_lower (eout sout : Nat) (r : Rat) :
 
 We show that `smtLibLower` can always be replaced with `lower`
 -/
+
+/-### Lower bounds -/
+
 theorem lsLawfulLower_smtLibLower (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) :
     SmtLibSemantics.IsLawfulLower r (SmtLibSemantics.smtLibLower.lower r : PackedFloat e s) := by
   simp [SmtLibSemantics.smtLibLower]
@@ -1110,7 +1090,7 @@ theorem smtLibLower_eq_lower (e s : Nat) (he : 0 < e) (hs : 0 < s) (r : ExtRat) 
 /-- info: 'Fp.smtLibLower_eq_lower' depends on axioms: [propext, Classical.choice, Quot.sound] -/
 #guard_msgs in #print axioms smtLibLower_eq_lower
 
-/-## Upper -/
+/-### Upper bounds -/
 
 theorem isLawfulUpper_smtLibUpper (e s : Nat) (he : 0 < e)  (hs : 0 < s) (r : ExtRat) :
     SmtLibSemantics.IsLawfulUpper r (SmtLibSemantics.smtLibUpper.upper r : PackedFloat e s) := by
@@ -1340,12 +1320,10 @@ info: 'Fp.smtLibUpper_eq_self_of_eq_toExtRat_of_not_isNaN' depends on axioms: [p
 -/
 #guard_msgs in #print axioms smtLibUpper_eq_self_of_eq_toExtRat_of_not_isNaN
 
--- /--
--- The abstract version of 'shouldRoundUp' that only depends on the rounding mode and the bits,
--- which matches the definition of `roundingDecision`.
--- -/
--- #check roundingDecision
--- def shouldRoundUp (rm : RoundingMode) (sign : Bool) (isEven : Bool) (guard : Bool) (sticky : Bool) : Bool :=
+/-# Rounding decision in terms of computable definitions -/
+
+
+-- TDOO: add a 'computableRoundingDecision.
 
 theorem round_eq_ite_roundingDecision_of_Number_of_nonneg {eout sout : Nat} (rm : RoundingMode)
     (sign : Bool)
@@ -1525,7 +1503,7 @@ theorem round_eq_ite_roundingDecision_of_Number_of_neg {eout sout : Nat} (rm : R
     intros hr
     grind only
 
-/-! ### clearSignificand theorems -/
+/-! # clearSignificand -/
 
 @[simp]
 theorem clearSignificand_sign (uf : UnpackedFloat e s)
@@ -1592,6 +1570,32 @@ theorem UnpackedFloat.clearSignificand_toRat_le_of_nonneg (uf : UnpackedFloat e 
     · grind only [Rat.le_of_lt, Rat.two_pow_pos]
   simp only [PackedFloat.Rat.natCast_le_natCast_iff_le]
   grind only
+
+/-- For a nonnegative unpacked float, the error from clearing guard/sticky bits is bounded by
+    2^(guardBitIdx + 1) ULPs at the significand level, i.e.,
+    `x.toRat - cleared.toRat < 2^(guardBitIdx + 1) * 2^(x.toExpInt)`.
+    This is the ULP of the target precision. -/
+theorem clearSignificand_toRat_sub_lt (uf : UnpackedFloat e s)
+    (targetExponentWidth targetSignificandWidth : Nat)
+    (h : 0 ≤ uf.toRat) :
+    uf.toRat - (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat <
+      (2 : Rat) ^ ((uf.guardBitIndex targetExponentWidth targetSignificandWidth).toNat + 1) *
+      (2 : Rat) ^ uf.toExpInt := by
+  sorry
+
+/--
+The result of 'clearSignificand' results in an unpacked float
+that can be represented in the target format, and has the same rational value as some `PackedFloat`.
+-/
+theorem exists_packedFloat_toRat_eq_clearSignificand_toRat (uf : UnpackedFloat e s)
+    (targetExponentWidth targetSignificandWidth : Nat) :
+    ∃ (pf : PackedFloat targetExponentWidth targetSignificandWidth),
+      pf.toRat = (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat := by
+  sorry
+
+
+
+/-! # guardBitIndex -/
 
 /--
 The guard bit index when interpreted as a natural number
@@ -1665,51 +1669,40 @@ theorem iff_iff_not_iff_not {p q : Prop} :
   grind
 
 
-/-- For a nonnegative unpacked float, the error from clearing guard/sticky bits is bounded by
-    2^(guardBitIdx + 1) ULPs at the significand level, i.e.,
-    `x.toRat - cleared.toRat < 2^(guardBitIdx + 1) * 2^(x.toExpInt)`.
-    This is the ULP of the target precision. -/
-theorem clearSignificand_toRat_sub_lt (uf : UnpackedFloat e s)
-    (targetExponentWidth targetSignificandWidth : Nat)
-    (h : 0 ≤ uf.toRat) :
-    uf.toRat - (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat <
-      (2 : Rat) ^ ((uf.guardBitIndex targetExponentWidth targetSignificandWidth).toNat + 1) *
-      (2 : Rat) ^ uf.toExpInt := by
-  sorry
+/-! # roundTowardZero -/
 
-/--
-The result of 'clearSignificand' results in an unpacked float
-that can be represented in the target format, and has the same rational value as some `PackedFloat`.
--/
-theorem exists_packedFloat_toRat_eq_clearSignificand_toRat (uf : UnpackedFloat e s)
-    (targetExponentWidth targetSignificandWidth : Nat) :
-    ∃ (pf : PackedFloat targetExponentWidth targetSignificandWidth),
-      pf.toRat = (uf.clearSignificand targetExponentWidth targetSignificandWidth).toRat := by
-  sorry
-
-
-
-theorem toExtRat_ufCleared_eq_lower_of_nonneg (x : UnpackedFloat e s)
+theorem toRat_roundTowardZero_eq_lower_of_nonneg (x : UnpackedFloat e s)
     (hx : 0 ≤ x.toRat) :
-    (ExtRat.Number (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat) =
-    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
+    (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat =
+    (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth).toRat
       := by
   sorry
 
-theorem toExtRat_ufCleared_eq_upper_of_neg (x : UnpackedFloat e s)
-    (hx : x.toRat < 0 ) :
-    (ExtRat.Number (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat) =
-    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
-      := by
-  sorry
-
-theorem toExtRat_successorAwayFromZero_eq_lower_of_neg (x : UnpackedFloat e s)
+theorem toRat_roundTowardZero_eq_upper_of_neg (x : UnpackedFloat e s)
     (hx : x.toRat < 0) :
-    (ExtRat.Number (x.successorAwayFromZero targetExponentWidth targetSignificandWidth).toRat) =
-    SmtLibSemantics.RoundableEmbed.embed (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth)
+    (x.roundTowardZero targetExponentWidth targetSignificandWidth).toRat =
+    (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth).toRat
       := by
   sorry
 
+
+/-# successorAwayFromZero -/
+
+theorem toRat_successorAwayFromZero_eq_upper_of_nonneg (x : UnpackedFloat e s)
+    (hx : 0 ≤ x.toRat) :
+    (x.successorAwayFromZero targetExponentWidth targetSignificandWidth).toRat =
+    (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth).toRat
+      := by
+  sorry
+
+theorem toRat_successorAwayFromZero_eq_upper_of_neg (x : UnpackedFloat e s)
+    (hx : x.toRat < 0) :
+    (x.successorAwayFromZero targetExponentWidth targetSignificandWidth).toRat =
+    (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat) : PackedFloat targetExponentWidth targetSignificandWidth).toRat
+      := by
+  sorry
+
+/-! # extractIsEven -/
 
 @[simp]
 theorem UnpackedFloat.extractIsEven_eq_isEven_lower_of_nonneg (x : UnpackedFloat e s)
@@ -1730,7 +1723,9 @@ theorem UnpackedFloat.extractIsEven_eq_isEven_upper_of_neg (x : UnpackedFloat e 
   sorry
 
 
-theorem extractGuardBit_eq_true_iff
+/-! # extractGuardBit -/
+
+theorem UnpackedFloat.extractGuardBit_eq_true_iff
     (hep : 1 < ep) (hsp : 0 < sp)
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
@@ -1756,13 +1751,13 @@ theorem extractGuardBit_eq_true_iff
 The guard bit is the bit at the lower index at '2' (when `su = sp + 2`),
 plus the offset from the exponent difference, which accounts for shifts when we are subnormal.
 -/
-theorem extractGuardBit_eq_getLsbD
+theorem UnpackedFloat.extractGuardBit_eq_getLsbD
     (hep : 1 < ep) (hsp : 0 < sp)
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
     (x : UnpackedFloat eu su) :
     x.extractGuardBit ep sp =  x.sig.getLsbD (su - (sp + 2) + (minNormalExp ep - x.ex.toInt).toNat)  := by
-  have := extractGuardBit_eq_true_iff hep hsp heu hsu x
+  have := UnpackedFloat.extractGuardBit_eq_true_iff hep hsp heu hsu x
   grind only [#0e2e4e0bb1f1e395]
 
 -- TODO: 'toRatSig' lemma about what the guardBit tracks.

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1044,6 +1044,41 @@ theorem eq_of_IsLawfulUpper_of_IsLawfulUpper
   grind only [PackedFloat.le_antisymm_of_ne_NaN]
 
 
+theorem IsLawfulUpper_eq_NaN_of_isNaN (e s : Nat) (r : ExtRat) (x : PackedFloat e s)
+    (hupper : SmtLibSemantics.IsLawfulUpper r x) :
+    x.isNaN = true → r = .NaN := by
+  intros hnan
+  have hupper1 := hupper.1
+  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+    ExtRat.ge_eq_le_symm] at hupper1
+  simp [hnan] at hupper1
+  grind only
+
+/--
+The result of 'IsLawfulLower' is unique and must be equal to the 'lower' computation.
+-/
+@[simp]
+theorem eq_upper_of_IsLawfulUpper (e s : Nat) (he : 0 < e) (hs : 0 < s)
+    (r : ExtRat)
+    (x : PackedFloat e s)
+    (hrnan : r ≠ .NaN)
+    (hupper : SmtLibSemantics.IsLawfulUpper r x) :
+    x = upper e s he hs r := by
+  apply eq_of_IsLawfulUpper_of_IsLawfulUpper
+  · intros hcontra
+    apply hrnan
+    apply IsLawfulUpper_eq_NaN_of_isNaN
+    · exact hupper
+    · grind only
+  · apply Classical.byContradiction
+    intros hcontra
+    apply hrnan
+    grind [ExtRat, upper]
+  · apply hupper
+  · exact IsLawfulUpper_upper e s he hs r
+
+
+
 /--
 two lawful lowers are equal to each other.
 -/
@@ -1058,6 +1093,41 @@ theorem eq_of_IsLawfulLower_of_IsLawfulLower
   have rlex' := hlowerx.2 y rley
   have rley' := hlowery.2 x rlex
   grind only [PackedFloat.le_antisymm_of_ne_NaN]
+
+theorem IsLawfulLower_eq_NaN_of_isNaN (e s : Nat) (r : ExtRat) (x : PackedFloat e s)
+    (hlower : SmtLibSemantics.IsLawfulLower r x) :
+    x.isNaN = true → r = .NaN := by
+  intros hnan
+  have hlower1 := hlower.1
+  simp only [SmtLibSemantics.smtLibV_embed_eq, PackedFloat.toExtRat_eq_toExtRat',
+    ExtRat.ge_eq_le_symm] at hlower1
+  simp [hnan] at hlower1
+  grind
+
+/--
+The result of 'IsLawfulLower' is unique and must be equal to the 'lower' computation.
+-/
+@[simp]
+theorem eq_lower_of_IsLawfulLower (e s : Nat) (he : 0 < e) (hs : 0 < s)
+    (r : ExtRat)
+    (x : PackedFloat e s)
+    (hrnan : r ≠ .NaN)
+    (hlower : SmtLibSemantics.IsLawfulLower r x) :
+    x = lower e s he hs r := by
+  apply eq_of_IsLawfulLower_of_IsLawfulLower
+  · intros hcontra
+    apply hrnan
+    apply IsLawfulLower_eq_NaN_of_isNaN
+    · exact hlower
+    · grind only
+  · apply Classical.byContradiction
+    intros hcontra
+    apply hrnan
+    grind [ExtRat, lower]
+  · apply hlower
+  · exact IsLawfulLower_lower e s he hs r
+
+
 
 @[simp]
 theorem embed_neg_eq_neg_embed {e s : Nat} (x : PackedFloat e s) :
@@ -1809,5 +1879,19 @@ theorem UnpackedFloat.extractStickyBit_eq_not_tieBreak_of_nonneg_of_guardBit
   · grind only
   · grind only
   · grind only
+
+
+theorem UnpackedFloat.toExtRat_round
+    (he : 1 < ep)
+    (hs : 0 < sp)
+    (heu : exponentWidth ep sp ≤ eu)
+    (hsu : sp + 2 ≤ su)
+    (x : UnpackedFloat eu su) :
+    (x.round rm (tep := ep) (tsp := sp) : EUnpackedFloat (exponentWidth ep sp) (sp + 1)).toExtRat =
+    ((SmtLibSemantics.smtLibRoundMethod (R := ExtRat) ep sp SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).round rm x.sign (ExtRat.Number x.toRat)).toExtRat := by
+  simp
+  rw [UnpackedFloat.round]
+
+  sorry
 
 end Fp

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -1658,12 +1658,21 @@ theorem extractGuardBit_eq_getLsbD
   have := extractGuardBit_eq_true_iff hep hsp heu hsu x
   grind only [#0e2e4e0bb1f1e395]
 
+-- TODO: 'toRatSig' lemma about what the guardBit tracks.
+
+theorem SmtLibSemantics.smtLibRoundMethod.lowerHalf_eq_decide (r : Rat) :
+    (smtLibRoundMethod e s smtLibV smtLibV).lowerHalf (ExtRat.Number r) =
+    (r - ((smtLibRoundMethod e s smtLibV smtLibV).lower (ExtRat.Number r)).toRat ≤ 2^e) := by
+  -- TODO: this is what I need to prove now.
+  sorry
+
+-- theorem le_toRatSig_of_extractGuardBit
 
 @[simp]
 theorem UnpackedFloat.extractGuardBit_eq_not_lowerHalf_of_nonneg (x : UnpackedFloat e s)
     (hx : x.sign = false) :
     x.extractGuardBit e s = ! (SmtLibSemantics.smtLibRoundMethod (R := ExtRat) e s SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).lowerHalf (ExtRat.Number x.toRat) := by
-  simp [SmtLibSemantics.smtLibRoundMethod]
+  -- simp [SmtLibSemantics.smtLibRoundMethod]
   sorry
 
 @[simp]

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -87,12 +87,13 @@ theorem BitVec.toInt_eq_toNat_of_toInt_nonneg {w : Nat}
     x.toInt = x.toNat := by
   rw [BitVec.toInt_eq_toNat_of_msb]
   rw [BitVec.msb_eq_toInt]
-  grind only/--
+  grind only
+
+/--
 The value of 'subSaturatingZero' when interpreted as a natural
-number equals what you'd expect, which interprets its arguments
-as integers.
+number and then casted to an integer equals saturating subtraction.
 -/
-theorem BitVec.toNat_subSaturatingZero_eq_ite
+theorem BitVec.natCast_toNat_subSaturatingZero_eq_ite
    (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
@@ -100,16 +101,21 @@ theorem BitVec.toNat_subSaturatingZero_eq_ite
       if x.toInt < base.toInt then 0 else (x.toInt - base.toInt) := by
   rw [← BitVec.toInt_eq_toNat_of_toInt_nonneg (x.subSaturatingZero base)]
   · rw [BitVec.toInt_subSaturatingZero_eq_ite hw x base hle hlt]
-  · apply BitVec.nonneg_toInt_subSaturatingZeZerow x base hle hlt
+  · apply BitVec.nonneg_toInt_subSaturatingZero hw x base hle hlt
 
-
-theorem BitVec.toNat_subSaturatingZero_max
+/--
+The value of 'subSaturatingZero' when interpreted as a natural
+number equals  saturating subtraction.
+-/
+theorem BitVec.toNat_subSaturatingZero_eq_ite_toNat
    (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
     (BitVec.subSaturatingZero x base).toNat =
-      max 0 (x.toInt - base.toInt) := by
-  rw [BitVec.toNat_subSaturatingZero_eq_ite hw x base hle hlt]
+      if x.toInt < base.toInt then 0 else (x.toInt - base.toInt).toNat := by
+  have := BitVec.natCast_toNat_subSaturatingZero_eq_ite hw x base hle hlt
+  split <;> grind only
+
 
 
 /--

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -47,7 +47,7 @@ The 'subSaturatingZero', when interpreted as an signed numbers,
 correctly keeps track of the distance from 'base' when 'x' is greater than or equal to 'base',
 and returns zero when 'x' is less than 'base'.
 -/
-theorem BitVec.toInt_subSaturatingZero {w : Nat} (hw : 0 < w) (x base : BitVec w)
+theorem BitVec.toInt_subSaturatingZero_eq_ite {w : Nat} (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
     (BitVec.subSaturatingZero x base).toInt =
@@ -76,7 +76,7 @@ theorem BitVec.nonneg_toInt_subSaturatingZero {w : Nat} (hw : 0 < w) (x base : B
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
     0 ≤ (BitVec.subSaturatingZero x base).toInt := by
-  rw [BitVec.toInt_subSaturatingZero hw x base hle hlt]
+  rw [BitVec.toInt_subSaturatingZero_eq_ite hw x base hle hlt]
   split <;> grind only
 
 /--
@@ -87,22 +87,30 @@ theorem BitVec.toInt_eq_toNat_of_toInt_nonneg {w : Nat}
     x.toInt = x.toNat := by
   rw [BitVec.toInt_eq_toNat_of_msb]
   rw [BitVec.msb_eq_toInt]
-  grind only
-
-/--
+  grind only/--
 The value of 'subSaturatingZero' when interpreted as a natural
 number equals what you'd expect, which interprets its arguments
 as integers.
 -/
-theorem BitVec.toNat_subSaturatingZero_eq
+theorem BitVec.toNat_subSaturatingZero_eq_ite
    (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
     (BitVec.subSaturatingZero x base).toNat =
       if x.toInt < base.toInt then 0 else (x.toInt - base.toInt) := by
   rw [← BitVec.toInt_eq_toNat_of_toInt_nonneg (x.subSaturatingZero base)]
-  · rw [BitVec.toInt_subSaturatingZero hw x base hle hlt]
-  · apply BitVec.nonneg_toInt_subSaturatingZero hw x base hle hlt
+  · rw [BitVec.toInt_subSaturatingZero_eq_ite hw x base hle hlt]
+  · apply BitVec.nonneg_toInt_subSaturatingZeZerow x base hle hlt
+
+
+theorem BitVec.toNat_subSaturatingZero_max
+   (hw : 0 < w) (x base : BitVec w)
+    (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
+    (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
+    (BitVec.subSaturatingZero x base).toNat =
+      max 0 (x.toInt - base.toInt) := by
+  rw [BitVec.toNat_subSaturatingZero_eq_ite hw x base hle hlt]
+
 
 /--
 Compute the guard bit index (from LSB) adjusted for subnormal shifting.

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -30,6 +30,82 @@ def roundingDecision (mode : RoundingMode) (sign : Bool) (significandEven : Bool
       false
 
 /--
+Return the distance of 'x' from 'base' if 'x ≥s base' (as signed numbers),
+and return '0' otherwise.
+-/
+def BitVec.distanceFromNonneg (base : BitVec w) (x : BitVec w) : BitVec w :=
+  if x.slt base then 0 else x - base
+
+/-
+BitVec.toNat_sub causes agressive unfolding when I don't want it to,
+so I remove it from the simp-set.
+-/
+attribute [-simp] BitVec.toNat_sub
+
+/--
+The 'distanceFromNonneg', when interpreted as an signed numbers,
+correctly keeps track of the distance from 'base' when 'x' is greater than or equal to 'base',
+and returns zero when 'x' is less than 'base'.
+-/
+theorem BitVec.toInt_distanceFromNonneg {w : Nat} (hw : 0 < w) (base x : BitVec w)
+    (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
+    (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
+    (BitVec.distanceFromNonneg base x).toInt =
+      if x.toInt < base.toInt then 0 else x.toInt - base.toInt := by
+  simp [distanceFromNonneg]
+  by_cases h : x.slt base
+  · simp [h]
+    rw [BitVec.slt_eq_decide] at h
+    simp at h
+    grind only
+  · simp only [h]
+    simp only [Bool.false_eq_true, ↓reduceIte]
+    rw [BitVec.slt_eq_decide] at h
+    simp only [decide_eq_true_eq, Int.not_lt] at h
+    simp only [show ¬x.toInt < base.toInt by grind, ↓reduceIte]
+    rw [BitVec.toInt_sub]
+    apply Int.bmod_eq_of_le
+    · simp only [Int.natCast_pow, Int.cast_ofNat_Int, hw, Int.two_pow_div_two_eq_sub_one_of_pos]
+      grind only
+    · simp; grind only
+
+/--
+The output of 'distanceFromNonneg' is always nonnegative.
+-/
+theorem BitVec.nonneg_toInt_distanceFromNonneg {w : Nat} (hw : 0 < w) (base x : BitVec w)
+    (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
+    (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
+    0 ≤ (BitVec.distanceFromNonneg base x).toInt := by
+  rw [BitVec.toInt_distanceFromNonneg hw base x hle hlt]
+  split <;> grind only
+
+/--
+If the integer interpretation is nonnegative, then the 'toInt' value equals to 'toNat' value.
+-/
+theorem BitVec.toInt_eq_toNat_of_toInt_nonneg {w : Nat}
+    (x : BitVec w) (hle : 0 ≤ x.toInt) :
+    x.toInt = x.toNat := by
+  rw [BitVec.toInt_eq_toNat_of_msb]
+  rw [BitVec.msb_eq_toInt]
+  grind only
+
+/--
+The value of 'distanceFromNonneg' when interpreted as a natural
+number equals what you'd expect, which interprets its arguments
+as integers.
+-/
+theorem BitVec.toNat_distanceFromNonneg_eq
+   (hw : 0 < w) (base x : BitVec w)
+    (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
+    (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
+    (BitVec.distanceFromNonneg base x).toNat =
+      if x.toInt < base.toInt then 0 else (x.toInt - base.toInt) := by
+  rw [← BitVec.toInt_eq_toNat_of_toInt_nonneg (base.distanceFromNonneg x)]
+  · rw [BitVec.toInt_distanceFromNonneg hw base x hle hlt]
+  · apply BitVec.nonneg_toInt_distanceFromNonneg hw base x hle hlt
+
+
+/--
 Compute the guard bit index (from LSB) adjusted for subnormal shifting.
 This is the position in the significand where the guard bit falls when
 rounding to `tsp` precision with the given target exponent format.
@@ -42,9 +118,9 @@ def UnpackedFloat.guardBitIndex {eu su : Nat}
     BitVec.ofNat su ((su - 1) - (tsp + 1))
   let targetMinNormalExp : BitVec eu :=
     BitVec.ofInt eu (minNormalExp tep)
-  let expGeMin :=
-    if uf.ex.slt targetMinNormalExp then targetMinNormalExp else uf.ex
-  let shiftAmtPositive := expGeMin - uf.ex
+  -- let expGeMin :=
+  --   if uf.ex.slt targetMinNormalExp then targetMinNormalExp else uf.ex
+  let shiftAmtPositive := BitVec.distanceFromNonneg targetMinNormalExp uf.ex
   guardBitIndexFromLsb + shiftAmtPositive.zeroExtend su
 
 /-- Extract the guard bit from an unpacked float at the target precision. -/

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -117,9 +117,7 @@ def UnpackedFloat.guardBitIndex {eu su : Nat}
     BitVec.ofNat su ((su - 1) - (tsp + 1))
   let targetMinNormalExp : BitVec eu :=
     BitVec.ofInt eu (minNormalExp tep)
-  -- let expGeMin :=
-  --   if uf.ex.slt targetMinNormalExp then targetMinNormalExp else uf.ex
-  let shiftAmtPositive := BitVec.subSaturatingZero uf.ex targetMinNormalExp
+  let shiftAmtPositive := BitVec.subSaturatingZero  targetMinNormalExp uf.ex
   guardBitIndexFromLsb + shiftAmtPositive.zeroExtend su
 
 /-- Extract the guard bit from an unpacked float at the target precision. -/
@@ -769,9 +767,9 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat) (EOut SOutNoHidden : N
 -- TODO: these are expensive checks, so move them into a separate file.
 -- All of these should succeed with zero failures (the ExtRat round matches
 -- the bitblasted UnpackedFloat round for every input).
-#eval checkRoundCorrect 4 5 4 2 .RNA
-#eval checkRoundCorrect 4 5 4 2 .RNE
-#eval checkRoundCorrect 4 5 4 2 .RTZ
-#eval checkRoundCorrect 2 6 2 4 .RTP
-#eval checkRoundCorrect 4 5 4 2 .RTP
-#eval checkRoundCorrect 4 5 4 2 .RTN
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNA
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
+#guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTP
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -30,10 +30,10 @@ def roundingDecision (mode : RoundingMode) (sign : Bool) (significandEven : Bool
       false
 
 /--
-Return the distance of 'x' from 'base' if 'x ≥s base' (as signed numbers),
-and return '0' otherwise.
+Return 'x - base', but if 'x' is less than 'base', return zero instead of a negative number.
 -/
-def BitVec.distanceFromNonneg (base : BitVec w) (x : BitVec w) : BitVec w :=
+@[bv_normalize]
+def BitVec.subSaturatingZero (x : BitVec w) (base : BitVec w) : BitVec w :=
   if x.slt base then 0 else x - base
 
 /-
@@ -43,16 +43,16 @@ so I remove it from the simp-set.
 attribute [-simp] BitVec.toNat_sub
 
 /--
-The 'distanceFromNonneg', when interpreted as an signed numbers,
+The 'subSaturatingZero', when interpreted as an signed numbers,
 correctly keeps track of the distance from 'base' when 'x' is greater than or equal to 'base',
 and returns zero when 'x' is less than 'base'.
 -/
-theorem BitVec.toInt_distanceFromNonneg {w : Nat} (hw : 0 < w) (base x : BitVec w)
+theorem BitVec.toInt_subSaturatingZero {w : Nat} (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
-    (BitVec.distanceFromNonneg base x).toInt =
+    (BitVec.subSaturatingZero x base).toInt =
       if x.toInt < base.toInt then 0 else x.toInt - base.toInt := by
-  simp [distanceFromNonneg]
+  simp [subSaturatingZero]
   by_cases h : x.slt base
   · simp [h]
     rw [BitVec.slt_eq_decide] at h
@@ -70,13 +70,13 @@ theorem BitVec.toInt_distanceFromNonneg {w : Nat} (hw : 0 < w) (base x : BitVec 
     · simp; grind only
 
 /--
-The output of 'distanceFromNonneg' is always nonnegative.
+The output of 'subSaturatingZero' is always nonnegative.
 -/
-theorem BitVec.nonneg_toInt_distanceFromNonneg {w : Nat} (hw : 0 < w) (base x : BitVec w)
+theorem BitVec.nonneg_toInt_subSaturatingZero {w : Nat} (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
-    0 ≤ (BitVec.distanceFromNonneg base x).toInt := by
-  rw [BitVec.toInt_distanceFromNonneg hw base x hle hlt]
+    0 ≤ (BitVec.subSaturatingZero x base).toInt := by
+  rw [BitVec.toInt_subSaturatingZero hw x base hle hlt]
   split <;> grind only
 
 /--
@@ -90,20 +90,19 @@ theorem BitVec.toInt_eq_toNat_of_toInt_nonneg {w : Nat}
   grind only
 
 /--
-The value of 'distanceFromNonneg' when interpreted as a natural
+The value of 'subSaturatingZero' when interpreted as a natural
 number equals what you'd expect, which interprets its arguments
 as integers.
 -/
-theorem BitVec.toNat_distanceFromNonneg_eq
-   (hw : 0 < w) (base x : BitVec w)
+theorem BitVec.toNat_subSaturatingZero_eq
+   (hw : 0 < w) (x base : BitVec w)
     (hle : - 2 ^ (w - 1) ≤ x.toInt - base.toInt)
     (hlt : x.toInt - base.toInt < 2 ^ (w - 1)) :
-    (BitVec.distanceFromNonneg base x).toNat =
+    (BitVec.subSaturatingZero x base).toNat =
       if x.toInt < base.toInt then 0 else (x.toInt - base.toInt) := by
-  rw [← BitVec.toInt_eq_toNat_of_toInt_nonneg (base.distanceFromNonneg x)]
-  · rw [BitVec.toInt_distanceFromNonneg hw base x hle hlt]
-  · apply BitVec.nonneg_toInt_distanceFromNonneg hw base x hle hlt
-
+  rw [← BitVec.toInt_eq_toNat_of_toInt_nonneg (x.subSaturatingZero base)]
+  · rw [BitVec.toInt_subSaturatingZero hw x base hle hlt]
+  · apply BitVec.nonneg_toInt_subSaturatingZero hw x base hle hlt
 
 /--
 Compute the guard bit index (from LSB) adjusted for subnormal shifting.
@@ -120,7 +119,7 @@ def UnpackedFloat.guardBitIndex {eu su : Nat}
     BitVec.ofInt eu (minNormalExp tep)
   -- let expGeMin :=
   --   if uf.ex.slt targetMinNormalExp then targetMinNormalExp else uf.ex
-  let shiftAmtPositive := BitVec.distanceFromNonneg targetMinNormalExp uf.ex
+  let shiftAmtPositive := BitVec.subSaturatingZero uf.ex targetMinNormalExp
   guardBitIndexFromLsb + shiftAmtPositive.zeroExtend su
 
 /-- Extract the guard bit from an unpacked float at the target precision. -/

--- a/Fp/Utils.lean
+++ b/Fp/Utils.lean
@@ -549,17 +549,18 @@ theorem BitVec.shiftLeft_one_ne_self_iff (x : BitVec w) :
   have := BitVec.shiftLeft_one_eq_self_iff_eq_zero x
   grind
 
-theorem BitVec.ne_iff_getLsbD_ne (x y : BitVec w) : x ≠ y ↔ (x.getLsbD ≠ y.getLsbD) := by
+theorem BitVec.ne_iff_getLsbD_ne (x y : BitVec w) : x ≠ y ↔ (∃ (i : Nat), x.getLsbD i ≠ y.getLsbD i) := by
   constructor
+  · intros hxy
+    apply Classical.byContradiction
+    intros hcontra
+    simp at hcontra
+    apply hxy
+    ext i
+    apply hcontra i
   · intros h1 h2
-    apply h1
-    apply BitVec.eq_of_getLsbD_eq
-    intros i hi
-    rw [h2]
-  · intros h1 h2
-    apply h1
     subst h2
-    simp only
+    grind only
 
 
 /--
@@ -963,3 +964,9 @@ theorem Int.two_pow_plus_one_div_two_eq_two_pow (e : Nat) :
    ((2 : Int)^e + 1) / 2 = (2 : Int) ^ (e - 1) := by
   norm_cast
   exact Nat.two_pow_succ_div_two
+
+@[simp]
+theorem Int.sub_toNat_eq_zero_of_le {a b : Int} (h : a ≤ b) :
+    (a - b).toNat = 0 := by
+  simp
+  grind only


### PR DESCRIPTION
This proves more bounds that will eventually let us show that guard, sticky, etc match the SMT-LIB definitions