### PR TITLE
feat: implement a simulation of the direct rounding as defined by SMT-LIB as circuits

### DIFF
--- a/Fp/Addition.lean
+++ b/Fp/Addition.lean
@@ -64,8 +64,7 @@ def EUnpackedFloat.add (m : RoundingMode) (x y : EUnpackedFloat (exponentWidth e
   else bif y.isZero then
     x
   else
-    UnpackedFloat.round (.add x.num y.num) m
-
+    (UnpackedFloat.add x.num y.num) |>.blastSmtLibRound e s m
 namespace PackedFloat
 
 @[bv_normalize]

--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -467,14 +467,6 @@ theorem maxNormalExp_plus_bias_lt_two_pow_exponentWidth (hs : 0 < s) :
 
 /-!
 ## Packed Floating Point Numbers
-
-This is a test module description
--/
-/-
-inductive Sign : Type
-| Positive : Sign
-| Negative : Sign
-deriving DecidableEq, Repr
 -/
 
 /--
@@ -1601,6 +1593,7 @@ uniform and easy to express using bitvector operations.
 Mathematically, an `UnpackedFloat e s` represents the real value
 
   (-1)^sign · sig · 2^(ex - (s - 1))
+  = (-1)^sign · (sig.toNat / 2 ^ (s - 1)) · 2^(ex.toInt)
 
 where:
 * `sign : Bool` is the sign bit,

--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -1708,6 +1708,11 @@ deriving Repr
 
 attribute [bv_normalize] EUnpackedFloat.ext_iff
 
+/--
+negate the number in an EUnpackedFloat.
+-/
+def EUnpackedFloat.neg (x : EUnpackedFloat e s) : EUnpackedFloat e s :=
+  { x with num := x.num.neg }
 
 inductive ExtDyadic where
   | NaN : ExtDyadic

--- a/Fp/Convert.lean
+++ b/Fp/Convert.lean
@@ -19,7 +19,7 @@ def EUnpackedFloat.setWidths (m : RoundingMode) (e' s')
     -- Promotion: no rounding needed!
     { euf with num := { euf.num with ex := euf.num.ex.signExtend _, sig := euf.num.sig.setWidth _ <<< (s' - s) } }
   else
-    euf.num.round m
+    euf.num |>.blastSmtLibRound e' s' m
 
 def PackedFloat.setWidths (m : RoundingMode) (e' s') (pf : PackedFloat e s) : PackedFloat e' s' :=
   (pf.unpack.setWidths m e' s').pack

--- a/Fp/Division.lean
+++ b/Fp/Division.lean
@@ -37,7 +37,7 @@ def EUnpackedFloat.div (m : RoundingMode) (x y : EUnpackedFloat (exponentWidth e
   else bif x.isZero || y.isInfinite then
     mkZero (x.num.sign ^^ y.num.sign)
   else
-    UnpackedFloat.round (.div x.num y.num) m
+    (UnpackedFloat.div x.num y.num) |>.blastSmtLibRound e s m
 
 namespace PackedFloat
 

--- a/Fp/FMA.lean
+++ b/Fp/FMA.lean
@@ -30,7 +30,7 @@ def EUnpackedFloat.fma (m : RoundingMode) (x y z : EUnpackedFloat (exponentWidth
   else bif x.isZero || y.isZero then
     z
   else bif z.isZero then
-    UnpackedFloat.round (.mul x.num y.num) m
+    (UnpackedFloat.mul x.num y.num) |>.blastSmtLibRound e s  m
   else bif UnpackedFloat.structBeq (.mul x.num y.num) (z.num.neg.extendWidths (by omega) (by omega)) then
     -- None of `x`, `y`, `x * y`, and `z` is an exact `0`. However, `x * y + z` is
     -- *still* exactly `0`! We must follow addition rules for sign of `0` in that case.
@@ -40,7 +40,7 @@ def EUnpackedFloat.fma (m : RoundingMode) (x y z : EUnpackedFloat (exponentWidth
     -- However, we keep it seperate as it's more expensive to check.
     mkZero (m == .RTN)
   else
-    UnpackedFloat.round (.fma x.num y.num z.num) m
+    (UnpackedFloat.fma x.num y.num z.num) |>.blastSmtLibRound e s m
 
 @[bv_normalize]
 def PackedFloat.fma (m : RoundingMode) (x y z : PackedFloat e s) : PackedFloat e s :=

--- a/Fp/Multiplication.lean
+++ b/Fp/Multiplication.lean
@@ -33,7 +33,7 @@ def EUnpackedFloat.mul (m : RoundingMode) (x y : EUnpackedFloat (exponentWidth e
   else bif x.isZero || y.isZero then
     mkZero (x.num.sign ^^ y.num.sign)
   else
-    UnpackedFloat.round (.mul x.num y.num) m
+    (UnpackedFloat.mul x.num y.num) |>.blastSmtLibRound e s m
 
 namespace PackedFloat
 

--- a/Fp/Negation.lean
+++ b/Fp/Negation.lean
@@ -2,11 +2,6 @@ import Fp.Basic
 import Fp.Unpacking
 
 @[bv_normalize]
-def EUnpackedFloat.neg (x : EUnpackedFloat (exponentWidth e s) (s + 1))
-  : EUnpackedFloat (exponentWidth e s) (s + 1) :=
-  { x with num := x.num.neg }
-
-@[bv_normalize]
 def EUnpackedFloat.abs (x : EUnpackedFloat (exponentWidth e s) (s + 1))
   : EUnpackedFloat (exponentWidth e s) (s + 1) :=
   { x with num := x.num.abs }

--- a/Fp/Sqrt.lean
+++ b/Fp/Sqrt.lean
@@ -84,7 +84,7 @@ def sqrt (x : PackedFloat e s) (m : RoundingMode) : PackedFloat e s :=
   if x.isZero then x
   else if (x.sign && !x.isZero) || x.isNaN then PackedFloat.getNaN e s
   else if (x.isInfinite && !x.sign) then PackedFloat.getInfinity e s false
-  else (UnpackedFloat.sqrt x.unpack.num) |> UnpackedFloat.round (mode := m) |>.pack
+  else (UnpackedFloat.sqrt x.unpack.num) |> UnpackedFloat.blastSmtLibRound (mode := m) e s |>.pack
 
 theorem square_sqrt_is_id (x : BitVec 3)
   : bit_sqrt (x.setWidth 6 * x.setWidth _) = x.setWidth _ <<< 1 := by

--- a/Fp/Theorems/UnpackedRound.lean
+++ b/Fp/Theorems/UnpackedRound.lean
@@ -655,17 +655,9 @@ theorem UnpackedFloat.toExtRat_round_eq_smtLibRound
     -- | The sticky bitt tracks whether 'r' is exactly representable.
     -- (hsticky : (∃ (pf : PackedFloat ep sp), pf.toRat = rstar)  x.extractStickyBit ep sp = false)
       :
-    (x.round rm (tep := ep) (tsp := sp) : EUnpackedFloat (exponentWidth ep sp) (sp + 1)) =
+    (x.blastSmtLibRound ep sp rm  : EUnpackedFloat (exponentWidth ep sp) (sp + 1)) =
     ((SmtLibSemantics.smtLibRoundMethod (R := ExtRat) ep sp SmtLibSemantics.smtLibV SmtLibSemantics.smtLibV).round rm x.sign (ExtRat.Number x.toRat)).unpack := by
-  rw [UnpackedFloat.round]
-  by_cases hzero : x.isZero
-  · simp [hzero, he, hs]
-    rw [UnpackedFloat.toRat_eq_toRat']
-    have : x.toRat' = 0 := by sorry
-    sorry
-  · simp [hzero]
-    rw [round_eq_ite_roundingDecision_of_Number_of_nonneg]
-    repeat sorry
-    -- TODO: can we change the definition of 'lower' so that we fold the over/underflow cases into the 'lower' and 'upper'?
+  rw [UnpackedFloat.blastSmtLibRound]
+  sorry
 
 end Fp

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -1017,9 +1017,9 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat)
 -- TODO: these are expensive checks, so move them into a separate file.
 -- All of these should succeed with zero failures (the ExtRat round matches
 -- the bitblasted UnpackedFloat round for every input).
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNA
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
-#guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTP
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN
+#guard_msgs(error, drop info) in #eval checkRoundCorrect 4 5 4 2 .RNA
+#guard_msgs(error, drop info) in #eval checkRoundCorrect 4 5 4 2 .RNE
+#guard_msgs(error, drop info) in #eval checkRoundCorrect 4 5 4 2 .RTZ
+#guard_msgs(error, drop info) in #eval checkRoundCorrect 2 6 2 4 .RTP
+#guard_msgs(error, drop info) in #eval checkRoundCorrect 4 5 4 2 .RTP
+#guard_msgs(error, drop info) in #eval checkRoundCorrect 4 5 4 2 .RTN

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -544,7 +544,7 @@ clamps the exponent, and returns the appropriate special case (underflow, overfl
 or the normal rounded number.
 -/
 @[bv_normalize]
-def rounderHandleOverAndUnderflow {eu : Nat} {tep tsp : Nat}
+def symfpuRounderHandleOverAndUnderflow {eu : Nat} {tep tsp : Nat}
   (roundedResult : UnpackedFloat eu (tsp + 1))
   (mode : RoundingMode) :
   EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
@@ -646,9 +646,10 @@ def UnpackedFloat.blastUpper {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp :
     uf.blastUpperNonneg tep tsp
 
 
+@[bv_normalize]
 def UnpackedFloat.blastIsLowerHalfNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
   !uf.blastExtractGuardBit tep tsp
-
+@[bv_normalize]
 def UnpackedFloat.blastIsLowerHalfNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
   uf.neg.blastExtractGuardBit tep tsp
 
@@ -660,10 +661,11 @@ def UnpackedFloat.blastIsLowerHalf {eu su : Nat} (uf : UnpackedFloat eu su) (tep
   else
     uf.blastIsLowerHalfNonneg tep tsp
 
-
+@[bv_normalize]
 def UnpackedFloat.blastIsEvenNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
   uf.blastExtractIsEven tep tsp
 
+@[bv_normalize]
 def UnpackedFloat.blastIsEvenNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
   !uf.blastExtractIsEven tep tsp
 
@@ -674,11 +676,24 @@ def UnpackedFloat.blastIsEven {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp 
   else
     uf.blastIsEvenNonneg tep tsp
 
+-- We are in the tie break cast if we are exactly in the middle, *and are also*
+-- in the normal range! If we are outside the normal range, then note that our distance to infinity
+-- is much farther away.
+@[bv_normalize]
+def UnpackedFloat.blastIsTieBreakNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.blastExtractGuardBit tep tsp && !uf.blastExtractStickyBit tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastIsTieBreakNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.blastExtractGuardBit tep tsp && !uf.blastExtractStickyBit tep tsp
+
 -- guard && !sticky
 @[bv_normalize]
 def UnpackedFloat.blastIsTieBreak {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
-  uf.blastExtractGuardBit tep tsp &&
-    !uf.blastExtractStickyBit tep tsp
+  if uf.sign then
+    uf.blastIsTieBreakNeg tep tsp
+  else
+    uf.blastIsTieBreakNonneg tep tsp
 
 
 @[bv_normalize]
@@ -711,7 +726,17 @@ def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (
   else if uf.blastIsLowerHalf tep tsp then uf.blastLower tep tsp
   else
     -- does not occur, since NaN and infinity are handled separately.
-    EUnpackedFloat.mkNaN
+
+/-
+      if isNaN r then roundMethod.lower r
+      else if gtZero r ∧ ¬ roundMethod.lowerHalf r then roundMethod.upper r
+      else if gtZero r ∧ roundMethod.lowerHalf r then roundMethod.lower r
+      else if isZero r then roundMethod.rounderForSign sign r
+      else if ltZero r ∧ ¬ roundMethod.lowerHalf r ∧ ¬ roundMethod.tieBreak r then roundMethod.upper r
+      else if ltZero r ∧ (roundMethod.lowerHalf r ∨ roundMethod.tieBreak r) then roundMethod.lower r
+      else .getNaN e s -- does not occur.
+
+-/    EUnpackedFloat.mkNaN
 
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRNA {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
@@ -775,11 +800,15 @@ def EUnpackedFloat.truncateFittingExponent {eu tep su tsp : Nat}
 def UnpackedFloat.blastSmtLibRound {eu su : Nat}
     (tep tsp : Nat) (mode : RoundingMode) (uf : UnpackedFloat eu su) :
     EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
-  let rounded := uf.blastSmtLibRoundAux tep tsp mode
-  let rounded := rounded.truncateFittingExponent
-  -- | TODO: re-establish the normalized exponent.
-  let rounded := rounded.normalize
-  rounded
+  if blastIsOverflowNonneg uf tep tsp then
+    blastRounderSpecialCaseOverflow mode uf.sign
+  else
+    -- if overflow then do overflow else call the rsest of the functions
+    let rounded := uf.blastSmtLibRoundAux tep tsp mode
+    let rounded := rounded.truncateFittingExponent
+    -- | TODO: re-establish the normalized exponent.
+    let rounded := rounded.normalize
+    rounded
 
 def EUnpackedFloat.blastSmtLibRound {eu su : Nat}
     (tep tsp : Nat) (mode : RoundingMode) (euf : EUnpackedFloat eu su) :
@@ -808,7 +837,7 @@ def UnpackedFloat.debugBlastSmtLibRound {eu su : Nat}
 The core rounding function, that rounds an `UnpackedFloat` to the target exponent and significand widths.
 Computes the shared prefix (guard/sticky bit extraction, significand clearing),
 then dispatches to `roundTowardZero` or `successorAwayFromZero` based on `roundingDecision`,
-and finally handles overflow/underflow via `rounderHandleOverAndUnderflow`.
+and finally handles overflow/underflow via `symfpuRounderHandleOverAndUnderflow`.
 -/
 @[bv_normalize]
 def UnpackedFloat.roundSymFPU {eu su : Nat} {tep tsp : Nat}
@@ -829,7 +858,7 @@ def UnpackedFloat.roundSymFPU {eu su : Nat} {tep tsp : Nat}
     inUf.blastSuccessorAwayFromZero tep tsp
   else
     inUf.blastRoundTowardZero tep tsp
-  rounderHandleOverAndUnderflow roundedUf mode
+  symfpuRounderHandleOverAndUnderflow roundedUf mode
 
 /-- Round an EUnpacked float, by ignoring NaN and infinity. -/
 @[bv_normalize]
@@ -919,7 +948,7 @@ def UnpackedFloat.debugRoundSymFPU {eu su : Nat} {tep tsp : Nat}
   let out := out ++ s!"\nlateUnderflow: {lateUnderflow} = roundedUf.ex({roundedUf.ex.toBitsStr}=int:{roundedUf.ex.toInt}) < minSubnormalExpBV({minSubnormalExpBV.toBitsStr}=int:{minSubnormalExpBV.toInt})"
 
   let result : EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
-    rounderHandleOverAndUnderflow roundedUf mode
+    symfpuRounderHandleOverAndUnderflow roundedUf mode
   let out := out ++ s!"\nresult(EUNum): {result.reprBinary} | (Q): {repr result.toExtRat}"
 
   -- let resultNormalized : EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -561,6 +561,214 @@ def rounderHandleOverAndUnderflow {eu : Nat} {tep tsp : Nat}
   else
     EUnpackedFloat.mkNumber <| roundedResult.truncateFittingExponent tep tsp
 
+@[bv_normalize]
+def blastIsUnderflowNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    Bool :=
+  let minSubnormalExpBV : BitVec eu :=
+    BitVec.ofInt eu (minSubnormalExp tep tsp)
+  let lateUnderflow : Bool :=
+    uf.ex.slt minSubnormalExpBV
+  lateUnderflow
+
+
+@[bv_normalize]
+def blastIsOverflowNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep _tsp : Nat) :
+    Bool :=
+  let maxNormalExpBV : BitVec eu :=
+    BitVec.ofInt eu (maxNormalExp tep)
+  let lateOverflow : Bool := maxNormalExpBV.slt uf.ex
+  lateOverflow
+
+@[bv_normalize]
+def UnpackedFloat.blastLowerNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if blastIsUnderflowNonneg uf tep tsp then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero false
+  else if blastIsOverflowNonneg uf tep tsp then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.maxNormal _ _ tep tsp false
+  else
+    EUnpackedFloat.mkNumber <| uf.blastRoundTowardZero tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastUpperNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+
+  if blastIsUnderflowNonneg uf tep tsp then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero true
+  else if blastIsOverflowNonneg uf tep tsp then
+    EUnpackedFloat.mkInfinity false
+  else
+    EUnpackedFloat.mkNumber <| uf.blastSuccessorAwayFromZero tep tsp
+
+-- lowerHalf = !guardBit
+@[bv_normalize]
+def UnpackedFloat.blastIsLowerHalf {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  !uf.blastExtractGuardBit tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastIsEven {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.blastExtractIsEven tep tsp
+
+-- guard && !sticky
+@[bv_normalize]
+def UnpackedFloat.blastIsTieBreak {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.blastExtractGuardBit tep tsp &&
+    !uf.blastExtractStickyBit tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  -- NaN, infinity is handled separately, so this only handles the other cases.
+  if uf.isZero then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+  else if ! uf.blastIsLowerHalf tep tsp && ! uf.blastIsTieBreak tep tsp then
+    uf.blastUpperNonneg tep tsp
+  else if uf.blastIsTieBreak tep tsp && uf.blastIsEven tep tsp then
+    uf.blastUpperNonneg tep tsp
+  else if uf.blastIsTieBreak tep tsp && !uf.blastIsEven tep tsp then
+    uf.blastLowerNonneg tep tsp
+  else if uf.blastIsLowerHalf tep tsp then
+    uf.blastLowerNonneg tep tsp
+  else
+    -- does not occur, since NaN and infinity are handled separately.
+    EUnpackedFloat.mkNaN
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRoundRNA {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.isZero then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+  else if !uf.blastIsLowerHalf tep tsp && !uf.blastIsTieBreak tep tsp then
+    if uf.sign then
+      uf.blastLowerNonneg tep tsp
+    else
+      uf.blastUpperNonneg tep tsp
+  else if uf.blastIsLowerHalf tep tsp || uf.blastIsTieBreak tep tsp then
+    if uf.sign then
+      uf.blastUpperNonneg tep tsp
+    else
+      uf.blastLowerNonneg tep tsp
+  else
+    -- does not occur, since NaN and infinity are handled separately.
+    EUnpackedFloat.mkNaN
+
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRoundRTP {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.isZero then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+  else if uf.sign then
+    uf.blastLowerNonneg tep tsp
+  else
+    uf.blastUpperNonneg tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRoundRTN {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.isZero then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+  else if uf.sign then
+    uf.blastUpperNonneg tep tsp
+  else
+    uf.blastLowerNonneg tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRoundRTZ {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.isZero then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+  else if uf.sign then
+    uf.blastUpperNonneg tep tsp
+  else
+    uf.blastLowerNonneg tep tsp
+
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRoundAux {eu su : Nat}
+    (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+    match mode with
+    | RoundingMode.RNE => blastSmtLibRoundRNE uf tep tsp
+    | RoundingMode.RNA => blastSmtLibRoundRNA uf tep tsp
+    | RoundingMode.RTP => blastSmtLibRoundRTP uf tep tsp
+    | RoundingMode.RTN => blastSmtLibRoundRTN uf tep tsp
+    | RoundingMode.RTZ => blastSmtLibRoundRTZ uf tep tsp
+
+@[bv_normalize]
+def EUnpackedFloat.truncateFittingExponent {eu tep su tsp : Nat}
+  (euf : EUnpackedFloat eu su) :
+  EUnpackedFloat (exponentWidth tep tsp) su :=
+  match euf.state with
+  | .Infinity => EUnpackedFloat.mkInfinity euf.sign
+  | .NaN => EUnpackedFloat.mkNaN
+  | .Number =>
+    EUnpackedFloat.mkNumber <| euf.num.truncateFittingExponent tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastSmtLibRound {eu su : Nat}
+    (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
+    EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
+  let rounded := uf.blastSmtLibRoundAux tep tsp mode
+  rounded.truncateFittingExponent
+
+
+def UnpackedFloat.debugBlastSmtLibRound {eu su : Nat}
+    (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
+    (EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) × String) :=
+  let out := ""
+  let out := out ++ s!"\n--- blastSmtLibRound: {repr uf} ---"
+  let out := out ++ s!"\n  input: {uf.reprBinary}"
+  let out := out ++ s!"\n  val (Q): {uf.toRat} = sig({uf.sig.toBitsStr}=nat:{uf.sig.toNat})) * 2 ** exp:([{uf.ex.toBitsStr}=int:{uf.ex.toInt}] - ({su - 1}))"
+  let result := uf.blastSmtLibRound tep tsp mode
+  let out := out ++ s!"\nresult(EUNum): {result.reprBinary} | (Q): {repr result.toExtRat}"
+  let resultPacked : PackedFloat tep tsp := result.pack
+  let out := out ++ s!"resultPacked: {resultPacked.reprBinary} | (Q): {repr resultPacked.toRat}"
+  (result, out)
+
+
+/--
+The core rounding function, that rounds an `UnpackedFloat` to the target exponent and significand widths.
+Computes the shared prefix (guard/sticky bit extraction, significand clearing),
+then dispatches to `roundTowardZero` or `successorAwayFromZero` based on `roundingDecision`,
+and finally handles overflow/underflow via `rounderHandleOverAndUnderflow`.
+-/
+@[bv_normalize]
+def UnpackedFloat.roundSymFPU {eu su : Nat} {tep tsp : Nat}
+  (inUf : UnpackedFloat eu su)
+  (mode : RoundingMode) :
+  EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
+  if _hzero : inUf.isZero then
+    EUnpackedFloat.mkZero inUf.sign
+  else
+  let shouldRoundUp := roundingDecision
+    (mode := mode)
+    (sign := inUf.sign)
+    (significandEven := inUf.blastExtractIsEven tep tsp)
+    (guardBit := inUf.blastExtractGuardBit tep tsp)
+    (stickyBit := inUf.blastExtractStickyBit tep tsp)
+    (_exact := false)
+  let roundedUf := if shouldRoundUp then
+    inUf.blastSuccessorAwayFromZero tep tsp
+  else
+    inUf.blastRoundTowardZero tep tsp
+  rounderHandleOverAndUnderflow roundedUf mode
+
+/-- Round an EUnpacked float, by ignoring NaN and infinity. -/
+@[bv_normalize]
+def EUnpackedFloat.blastRoundSymFPU {eu su : Nat} {tep tsp : Nat}
+  (inEuf : EUnpackedFloat eu su)
+  (mode : RoundingMode) :
+  EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
+  if inEuf.isNumber then
+    let inUf := inEuf.num
+    let out := UnpackedFloat.roundSymFPU (tep := tep) (tsp := tsp) inUf mode
+    -- out.normalize
+    out
+  else if inEuf.isNaN then EUnpackedFloat.mkNaN
+  else EUnpackedFloat.mkInfinity inEuf.sign
+
+
 /--
 Debug variant of rounding: mirrors `UnpackedFloat.round` step-by-step while logging
 each intermediate value to a string.
@@ -572,7 +780,7 @@ Preconditions for rounding to succeed:
 (hs' : su >= 1) :
 -/
 @[bv_normalize]
-def UnpackedFloat.debugRound {eu su : Nat} {tep tsp : Nat}
+def UnpackedFloat.debugRoundSymFPU {eu su : Nat} {tep tsp : Nat}
   (inUf : UnpackedFloat eu su)
   (mode : RoundingMode) :
   (EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) × String) :=
@@ -644,72 +852,12 @@ def UnpackedFloat.debugRound {eu su : Nat} {tep tsp : Nat}
   let out := out ++ s!"\nresultPacked: {resultPacked.reprBinary} | (Q): {repr resultPacked.toRat}"
   (result, out)
 
-/--
-The core rounding function, that rounds an `UnpackedFloat` to the target exponent and significand widths.
-Computes the shared prefix (guard/sticky bit extraction, significand clearing),
-then dispatches to `roundTowardZero` or `successorAwayFromZero` based on `roundingDecision`,
-and finally handles overflow/underflow via `rounderHandleOverAndUnderflow`.
--/
-@[bv_normalize]
-def UnpackedFloat.round {eu su : Nat} {tep tsp : Nat}
-  (inUf : UnpackedFloat eu su)
-  (mode : RoundingMode) :
-  EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
-  if _hzero : inUf.isZero then
-    EUnpackedFloat.mkZero inUf.sign
-  else
-  -- round a normalized, normal float.
-  -- let earlyOverflow : Bool := inUf.ex.sgt (BitVec.ofInt eu (maxNormalExp tep))
-  -- if _hoverflow : earlyOverflow then
-  --   blastRounderSpecialCaseOverflow mode inUf.sign
-  -- else
-
-  -- early underflow:
-  -- let earlyUnderflow : Bool := inUf.ex.slt (BitVec.ofInt eu (minSubnormalExp tep tsp))
-  -- if _hunderflow : earlyUnderflow then
-  --   rounderSpecialCaseUnderflow mode inUf.sign
-  -- else
-
-  let shouldRoundUp := roundingDecision
-    (mode := mode)
-    (sign := inUf.sign)
-    (significandEven := inUf.blastExtractIsEven tep tsp)
-    (guardBit := inUf.blastExtractGuardBit tep tsp)
-    (stickyBit := inUf.blastExtractStickyBit tep tsp)
-    (_exact := false)
-  let roundedUf := if shouldRoundUp then
-    inUf.blastSuccessorAwayFromZero tep tsp
-  else
-    inUf.blastRoundTowardZero tep tsp
-  rounderHandleOverAndUnderflow roundedUf mode
-
-/-- Round an EUnpacked float, by ignoring NaN and infinity. -/
-@[bv_normalize]
-def EUnpackedFloat.blastRound {eu su : Nat} {tep tsp : Nat}
-  (inEuf : EUnpackedFloat eu su)
-  (mode : RoundingMode) :
-  EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
-  if inEuf.isNumber then
-    let inUf := inEuf.num
-    let out := UnpackedFloat.round (tep := tep) (tsp := tsp) inUf mode
-    -- out.normalize
-    out
-  else if inEuf.isNaN then EUnpackedFloat.mkNaN
-  else EUnpackedFloat.mkInfinity inEuf.sign
-
-/--
-Prove that the debug mode round function is equal to the core round function.
--/
-theorem debugRound_eq_round {eu su : Nat} {tep tsp : Nat}
-  (inUf : UnpackedFloat eu su)
-  (mode : RoundingMode) :
-  (UnpackedFloat.debugRound (tep := tep) (tsp := tsp)
-    inUf mode).1 =
-  UnpackedFloat.round (tep := tep) (tsp := tsp)
-    inUf mode := sorry
 
 -- TODO: these are expensive checks, so move them into a separate file.
-def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat) (EOut SOutNoHidden : Nat) (mode : RoundingMode) : IO Bool := do
+def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat)
+  (EOut SOutNoHidden : Nat)
+  (mode : RoundingMode)
+  : IO Bool := do
   let mut outError : String := ""
   let mut nsucceeded : Nat := 0
   let mut nfailed : Nat := 0
@@ -732,7 +880,8 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat) (EOut SOutNoHidden : N
     let originalUnpacked := originalEUnpacked.num
     let originalNormalized := originalUnpacked.normalize
     let (outputRoundedEUnpacked, log) :=
-      UnpackedFloat.debugRound (tep := EOut) (tsp := SOutNoHidden)
+      -- UnpackedFloat.debugRoundSymFPU (tep := EOut) (tsp := SOutNoHidden)
+      UnpackedFloat.debugBlastSmtLibRound (tep := EOut) (tsp := SOutNoHidden)
         originalNormalized mode
     let outputRoundedPacked := outputRoundedEUnpacked.pack
 
@@ -782,6 +931,7 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat) (EOut SOutNoHidden : N
     let fracSuccess : Float := (nsucceeded.toFloat * 100.0) / ((nsucceeded + nfailed).toFloat)
     throw (IO.Error.userError s!"({nsucceeded} succeeded / {nsucceeded + nfailed} total) ({fracSuccess}% succeeded) ({nfailed} failures) ❌\n{outError}")
   return nfailed = 0
+
 
 -- TODO: these are expensive checks, so move them into a separate file.
 -- All of these should succeed with zero failures (the ExtRat round matches

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -645,14 +645,34 @@ def UnpackedFloat.blastUpper {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp :
   else
     uf.blastUpperNonneg tep tsp
 
+
+def UnpackedFloat.blastIsLowerHalfNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  !uf.blastExtractGuardBit tep tsp
+
+def UnpackedFloat.blastIsLowerHalfNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.neg.blastExtractGuardBit tep tsp
+
 -- lowerHalf = !guardBit
 @[bv_normalize]
 def UnpackedFloat.blastIsLowerHalf {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
-  !uf.blastExtractGuardBit tep tsp
+  if uf.sign then
+    uf.blastIsLowerHalfNeg tep tsp
+  else
+    uf.blastIsLowerHalfNonneg tep tsp
+
+
+def UnpackedFloat.blastIsEvenNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.blastExtractIsEven tep tsp
+
+def UnpackedFloat.blastIsEvenNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  !uf.blastExtractIsEven tep tsp
 
 @[bv_normalize]
 def UnpackedFloat.blastIsEven {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
-  uf.blastExtractIsEven tep tsp
+  if uf.sign then
+    uf.blastIsEvenNeg tep tsp
+  else
+    uf.blastIsEvenNonneg tep tsp
 
 -- guard && !sticky
 @[bv_normalize]
@@ -669,20 +689,26 @@ def UnpackedFloat.blastRounderForSign {eu su : Nat} (uf : UnpackedFloat eu su) (
   else
     uf.blastLower tep tsp
 
+/-
+      if isNaN r then roundMethod.lower r
+      else if ¬ (isZero r) ∧ !roundMethod.lowerHalf r ∧ !roundMethod.tieBreak r then roundMethod.upper r
+      else if ¬ (isZero r) ∧ roundMethod.tieBreak r ∧ roundMethod.isEven (roundMethod.upper r) then roundMethod.upper r
+      else if ¬ (isZero r) ∧ roundMethod.tieBreak r ∧ roundMethod.isEven (roundMethod.lower r) then roundMethod.lower r
+      else if ¬ (isZero r) ∧ roundMethod.lowerHalf r then roundMethod.lower r
+      else if isZero r then roundMethod.rounderForSign sign r
+      else .getNaN e s -- does not occur.
+
+-/
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   -- NaN, infinity is handled separately, so this only handles the other cases.
   if uf.isZero then
     uf.blastRounderForSign tep tsp
-  else if ! uf.blastIsLowerHalf tep tsp && ! uf.blastIsTieBreak tep tsp then
-    uf.blastUpper tep tsp
-  else if uf.blastIsTieBreak tep tsp && uf.blastIsEven tep tsp then
-    uf.blastUpper tep tsp
-  else if uf.blastIsTieBreak tep tsp && !uf.blastIsEven tep tsp then
-    uf.blastLower tep tsp
-  else if uf.blastIsLowerHalf tep tsp then
-    uf.blastLower tep tsp
+  else if ! uf.blastIsLowerHalf tep tsp && ! uf.blastIsTieBreak tep tsp then uf.blastUpper tep tsp
+  else if uf.blastIsTieBreak tep tsp && !uf.blastIsEven tep tsp then uf.blastUpper tep tsp
+  else if uf.blastIsTieBreak tep tsp && uf.blastIsEven tep tsp then uf.blastLower tep tsp
+  else if uf.blastIsLowerHalf tep tsp then uf.blastLower tep tsp
   else
     -- does not occur, since NaN and infinity are handled separately.
     EUnpackedFloat.mkNaN
@@ -690,23 +716,12 @@ def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRNA {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
-  if uf.isZero then
-    uf.blastRounderForSign tep tsp
-  else if !uf.blastIsLowerHalf tep tsp && !uf.blastIsTieBreak tep tsp then
-    if uf.sign then
-      uf.blastLower tep tsp
-    else
-      uf.blastUpper tep tsp
-  else if uf.blastIsLowerHalf tep tsp || uf.blastIsTieBreak tep tsp then
-    if uf.sign then
-      uf.blastUpper tep tsp
-    else
-      uf.blastLower tep tsp
-  else
-    -- does not occur, since NaN and infinity are handled separately.
-    EUnpackedFloat.mkNaN
-
-
+  if uf.isZero then uf.blastRounderForSign tep tsp
+  else if uf.sign = false && !uf.blastIsLowerHalf tep tsp then uf.blastUpper tep tsp
+  else if uf.sign = false && uf.blastIsLowerHalf tep tsp then uf.blastLower tep tsp
+  else if uf.sign = true && !uf.blastIsLowerHalf tep tsp && !uf.blastIsTieBreak tep tsp then uf.blastUpper tep tsp
+  else if uf.sign = true && (uf.blastIsLowerHalf tep tsp || uf.blastIsTieBreak tep tsp) then uf.blastLower tep tsp
+  else EUnpackedFloat.mkNaN   -- does not occur, since NaN and infinity are handled separately.
 
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRTP {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
@@ -758,13 +773,22 @@ def EUnpackedFloat.truncateFittingExponent {eu tep su tsp : Nat}
 
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRound {eu su : Nat}
-    (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
+    (tep tsp : Nat) (mode : RoundingMode) (uf : UnpackedFloat eu su) :
     EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
   let rounded := uf.blastSmtLibRoundAux tep tsp mode
   let rounded := rounded.truncateFittingExponent
   -- | TODO: re-establish the normalized exponent.
   let rounded := rounded.normalize
   rounded
+
+def EUnpackedFloat.blastSmtLibRound {eu su : Nat}
+    (tep tsp : Nat) (mode : RoundingMode) (euf : EUnpackedFloat eu su) :
+    EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
+  match euf.state with
+  | .Infinity => EUnpackedFloat.mkInfinity euf.sign
+  | .NaN => EUnpackedFloat.mkNaN
+  | .Number => euf.num.blastSmtLibRound tep tsp mode
+
 
 def UnpackedFloat.debugBlastSmtLibRound {eu su : Nat}
     (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
@@ -821,6 +845,10 @@ def EUnpackedFloat.blastRoundSymFPU {eu su : Nat} {tep tsp : Nat}
   else if inEuf.isNaN then EUnpackedFloat.mkNaN
   else EUnpackedFloat.mkInfinity inEuf.sign
 
+
+def UnpackedFloat.blastRound {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
+    EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
+  uf.blastSmtLibRound tep tsp mode
 
 /--
 Debug variant of rounding: mirrors `UnpackedFloat.round` step-by-step while logging
@@ -989,9 +1017,9 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat)
 -- TODO: these are expensive checks, so move them into a separate file.
 -- All of these should succeed with zero failures (the ExtRat round matches
 -- the bitblasted UnpackedFloat round for every input).
--- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNA
--- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
--- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
--- #guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNA
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
+#guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
 #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTP
 #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -122,6 +122,8 @@ theorem BitVec.toNat_subSaturatingZero_eq_ite_toNat
 Compute the guard bit index (from LSB) adjusted for subnormal shifting.
 This is the position in the significand where the guard bit falls when
 rounding to `tsp` precision with the given target exponent format.
+
+TODO: can't we do this with 'lsbBitIndex'? Possibly!
 -/
 @[bv_normalize]
 def UnpackedFloat.guardBitIndex {eu su : Nat}
@@ -562,43 +564,82 @@ def rounderHandleOverAndUnderflow {eu : Nat} {tep tsp : Nat}
     EUnpackedFloat.mkNumber <| roundedResult.truncateFittingExponent tep tsp
 
 @[bv_normalize]
-def blastIsUnderflowNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+def UnpackedFloat.blastIsUnderflowNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     Bool :=
-  let minSubnormalExpBV : BitVec eu :=
-    BitVec.ofInt eu (minSubnormalExp tep tsp)
-  let lateUnderflow : Bool :=
-    uf.ex.slt minSubnormalExpBV
-  lateUnderflow
+  let minSubnormalExpBV : BitVec eu := BitVec.ofInt eu (minSubnormalExp tep tsp)
+  uf.ex.slt minSubnormalExpBV
 
 
 @[bv_normalize]
-def blastIsOverflowNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep _tsp : Nat) :
+def UnpackedFloat.blastIsOverflowNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep _tsp : Nat) :
     Bool :=
   let maxNormalExpBV : BitVec eu :=
     BitVec.ofInt eu (maxNormalExp tep)
-  let lateOverflow : Bool := maxNormalExpBV.slt uf.ex
-  lateOverflow
+  maxNormalExpBV.slt uf.ex
 
 @[bv_normalize]
 def UnpackedFloat.blastLowerNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
-  if blastIsUnderflowNonneg uf tep tsp then
+  let next := uf.blastRoundTowardZero tep tsp
+  if next.blastIsUnderflowNonneg tep tsp then
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero false
-  else if blastIsOverflowNonneg uf tep tsp then
+  else if next.blastIsOverflowNonneg tep tsp then
     EUnpackedFloat.mkNumber <| UnpackedFloat.maxNormal _ _ tep tsp false
   else
-    EUnpackedFloat.mkNumber <| uf.blastRoundTowardZero tep tsp
+    EUnpackedFloat.mkNumber <| next
+
+/--
+If a number has a guard/sticky bit, then it needs to be rounded.
+If it does not, then no rounding is necessary,
+and the result is already correctly rounded for all rounding modes.
+-/
+def UnpackedFloat.needsRounding {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) : Bool :=
+  uf.blastExtractGuardBit tep tsp || uf.blastExtractStickyBit tep tsp
+
+
+def UnpackedFloat.blastSuccessorAwayFromZeroIfNeeded {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    UnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.needsRounding tep tsp then
+    uf.blastSuccessorAwayFromZero tep tsp
+  else
+    uf.blastRoundTowardZero tep tsp -- this will be a noop
 
 @[bv_normalize]
 def UnpackedFloat.blastUpperNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
-
-  if blastIsUnderflowNonneg uf tep tsp then
+  let next := uf.blastSuccessorAwayFromZeroIfNeeded tep tsp
+  if next.blastIsUnderflowNonneg tep tsp then
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero true
-  else if blastIsOverflowNonneg uf tep tsp then
+  else if next.blastIsOverflowNonneg tep tsp then
     EUnpackedFloat.mkInfinity false
   else
-    EUnpackedFloat.mkNumber <| uf.blastSuccessorAwayFromZero tep tsp
+    EUnpackedFloat.mkNumber <| next
+
+@[bv_normalize]
+def UnpackedFloat.blastLowerNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  uf.neg.blastUpperNonneg tep tsp |>.neg
+
+@[bv_normalize]
+def UnpackedFloat.blastLower {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.sign then
+    uf.blastLowerNeg tep tsp
+  else
+    uf.blastLowerNonneg tep tsp
+
+@[bv_normalize]
+def UnpackedFloat.blastUpperNeg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  uf.neg.blastLowerNonneg tep tsp |>.neg
+
+@[bv_normalize]
+def UnpackedFloat.blastUpper {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.sign then
+    uf.blastUpperNeg tep tsp
+  else
+    uf.blastUpperNonneg tep tsp
 
 -- lowerHalf = !guardBit
 @[bv_normalize]
@@ -615,6 +656,15 @@ def UnpackedFloat.blastIsTieBreak {eu su : Nat} (uf : UnpackedFloat eu su) (tep 
   uf.blastExtractGuardBit tep tsp &&
     !uf.blastExtractStickyBit tep tsp
 
+
+@[bv_normalize]
+def UnpackedFloat.blastRounderForSign {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
+    EUnpackedFloat (eu + 1) (tsp + 1) :=
+  if uf.sign then
+    uf.blastUpper tep tsp
+  else
+    uf.blastLower tep tsp
+
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
@@ -622,13 +672,13 @@ def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (
   if uf.isZero then
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
   else if ! uf.blastIsLowerHalf tep tsp && ! uf.blastIsTieBreak tep tsp then
-    uf.blastUpperNonneg tep tsp
+    uf.blastUpper tep tsp
   else if uf.blastIsTieBreak tep tsp && uf.blastIsEven tep tsp then
-    uf.blastUpperNonneg tep tsp
+    uf.blastUpper tep tsp
   else if uf.blastIsTieBreak tep tsp && !uf.blastIsEven tep tsp then
-    uf.blastLowerNonneg tep tsp
+    uf.blastLower tep tsp
   else if uf.blastIsLowerHalf tep tsp then
-    uf.blastLowerNonneg tep tsp
+    uf.blastLower tep tsp
   else
     -- does not occur, since NaN and infinity are handled separately.
     EUnpackedFloat.mkNaN
@@ -640,28 +690,27 @@ def UnpackedFloat.blastSmtLibRoundRNA {eu su : Nat} (uf : UnpackedFloat eu su) (
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
   else if !uf.blastIsLowerHalf tep tsp && !uf.blastIsTieBreak tep tsp then
     if uf.sign then
-      uf.blastLowerNonneg tep tsp
+      uf.blastLower tep tsp
     else
-      uf.blastUpperNonneg tep tsp
+      uf.blastUpper tep tsp
   else if uf.blastIsLowerHalf tep tsp || uf.blastIsTieBreak tep tsp then
     if uf.sign then
-      uf.blastUpperNonneg tep tsp
+      uf.blastUpper tep tsp
     else
-      uf.blastLowerNonneg tep tsp
+      uf.blastLower tep tsp
   else
     -- does not occur, since NaN and infinity are handled separately.
     EUnpackedFloat.mkNaN
+
 
 
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRTP {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   if uf.isZero then
-    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
-  else if uf.sign then
-    uf.blastLowerNonneg tep tsp
+    uf.blastRounderForSign tep tsp
   else
-    uf.blastUpperNonneg tep tsp
+    uf.blastUpper tep tsp
 
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRTN {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
@@ -669,9 +718,9 @@ def UnpackedFloat.blastSmtLibRoundRTN {eu su : Nat} (uf : UnpackedFloat eu su) (
   if uf.isZero then
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
   else if uf.sign then
-    uf.blastUpperNonneg tep tsp
+    uf.blastUpper tep tsp
   else
-    uf.blastLowerNonneg tep tsp
+    uf.blastLower tep tsp
 
 @[bv_normalize]
 def UnpackedFloat.blastSmtLibRoundRTZ {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
@@ -679,9 +728,9 @@ def UnpackedFloat.blastSmtLibRoundRTZ {eu su : Nat} (uf : UnpackedFloat eu su) (
   if uf.isZero then
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
   else if uf.sign then
-    uf.blastUpperNonneg tep tsp
+    uf.blastUpper tep tsp
   else
-    uf.blastLowerNonneg tep tsp
+    uf.blastLower tep tsp
 
 
 @[bv_normalize]
@@ -936,9 +985,32 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat)
 -- TODO: these are expensive checks, so move them into a separate file.
 -- All of these should succeed with zero failures (the ExtRat round matches
 -- the bitblasted UnpackedFloat round for every input).
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNA
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
-#guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
+-- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNA
+-- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
+-- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
+-- #guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
+/--
+error: (948 succeeded / 960 total) (98.750000% succeeded) (12 failures) ❌
+
+Failed ❌ | original EUNum(- 0b111000=nat:56 * 2^(0b10111=int:-9 - 5))
+  original (packed) - (subnorm:true) sig:0b00111=nat:7 ex:0b0000=nat:0 bias:7 expval:-7 = (some -7/2048)
+  original (Q) some (-7 : Rat)/2048
+  original (eunpacked) "EUNum(- 0b111000=nat:56 * 2^(0b10111=int:-9 - 5))"
+  --
+  output rounded (eunpacked) EUNum(- 0b000=nat:0 * 2^(0b00000=int:0 - 2))
+  output rounded (eunpacked.Q) ExtRat.Number 0
+  output rounded (packed) - (subnorm:false) sig:0b00=nat:0 ex:0b0111=nat:7 bias:7 expval:0 = (some -1)
+  output rounded (packed.Q) ExtRat.Number -1
+  --
+  expected (packed) - (subnorm:false) sig:0b00=nat:0 ex:0b0000=nat:0 bias:7 expval:-7 = (some 0)
+  expected (Q) ExtRat.Number 0
+  expected (eunpacked) EUNum(- 0b000=nat:0 * 2^(0b10000=int:-16 - 2))
+
+
+--- blastSmtLibRound: { sign := true, ex := 0x17#5, sig := 0x38#6 } ---
+  input: - 0b111000=nat:56 * 2^(0b10111=int:-9 - 5)
+  val (Q): -7/2048 = sig(0b111000=nat:56)) * 2 ** exp:([0b10111=int:-9] - (5))
+result(EUNum): EUNum(- 0b000=nat:0 * 2^(0b00000=int:0 - 2)) | (Q): ExtRat.Number 0resultPacked: - (subnorm:false) sig:0b00=nat:0 ex:0b0111=nat:7 bias:7 expval:0 = (some -1) | (Q): -1
+-/
 #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTP
-#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN
+-- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN

--- a/Fp/UnpackedRound.lean
+++ b/Fp/UnpackedRound.lean
@@ -582,6 +582,7 @@ def UnpackedFloat.blastLowerNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   let next := uf.blastRoundTowardZero tep tsp
   if next.blastIsUnderflowNonneg tep tsp then
+    -- greatest lower bound of 0 is +0
     EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero false
   else if next.blastIsOverflowNonneg tep tsp then
     EUnpackedFloat.mkNumber <| UnpackedFloat.maxNormal _ _ tep tsp false
@@ -608,8 +609,11 @@ def UnpackedFloat.blastSuccessorAwayFromZeroIfNeeded {eu su : Nat} (uf : Unpacke
 def UnpackedFloat.blastUpperNonneg {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   let next := uf.blastSuccessorAwayFromZeroIfNeeded tep tsp
-  if next.blastIsUnderflowNonneg tep tsp then
-    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero true
+  if next.isZero then
+    -- least upper bound of 0 is -0
+    EUnpackedFloat.mkZero true
+  else if next.blastIsUnderflowNonneg tep tsp then
+    EUnpackedFloat.mkNumber <| UnpackedFloat.minSubnormalForPackedFloat _ _ tep tsp false
   else if next.blastIsOverflowNonneg tep tsp then
     EUnpackedFloat.mkInfinity false
   else
@@ -670,7 +674,7 @@ def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   -- NaN, infinity is handled separately, so this only handles the other cases.
   if uf.isZero then
-    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+    uf.blastRounderForSign tep tsp
   else if ! uf.blastIsLowerHalf tep tsp && ! uf.blastIsTieBreak tep tsp then
     uf.blastUpper tep tsp
   else if uf.blastIsTieBreak tep tsp && uf.blastIsEven tep tsp then
@@ -687,7 +691,7 @@ def UnpackedFloat.blastSmtLibRoundRNE {eu su : Nat} (uf : UnpackedFloat eu su) (
 def UnpackedFloat.blastSmtLibRoundRNA {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   if uf.isZero then
-    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
+    uf.blastRounderForSign tep tsp
   else if !uf.blastIsLowerHalf tep tsp && !uf.blastIsTieBreak tep tsp then
     if uf.sign then
       uf.blastLower tep tsp
@@ -716,9 +720,7 @@ def UnpackedFloat.blastSmtLibRoundRTP {eu su : Nat} (uf : UnpackedFloat eu su) (
 def UnpackedFloat.blastSmtLibRoundRTN {eu su : Nat} (uf : UnpackedFloat eu su) (tep tsp : Nat) :
     EUnpackedFloat (eu + 1) (tsp + 1) :=
   if uf.isZero then
-    EUnpackedFloat.mkNumber <| UnpackedFloat.mkZero uf.sign
-  else if uf.sign then
-    uf.blastUpper tep tsp
+    uf.blastRounderForSign tep tsp
   else
     uf.blastLower tep tsp
 
@@ -759,8 +761,10 @@ def UnpackedFloat.blastSmtLibRound {eu su : Nat}
     (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
     EUnpackedFloat (exponentWidth tep tsp) (tsp + 1) :=
   let rounded := uf.blastSmtLibRoundAux tep tsp mode
-  rounded.truncateFittingExponent
-
+  let rounded := rounded.truncateFittingExponent
+  -- | TODO: re-establish the normalized exponent.
+  let rounded := rounded.normalize
+  rounded
 
 def UnpackedFloat.debugBlastSmtLibRound {eu su : Nat}
     (uf : UnpackedFloat eu su) (tep tsp : Nat) (mode : RoundingMode) :
@@ -812,7 +816,7 @@ def EUnpackedFloat.blastRoundSymFPU {eu su : Nat} {tep tsp : Nat}
   if inEuf.isNumber then
     let inUf := inEuf.num
     let out := UnpackedFloat.roundSymFPU (tep := tep) (tsp := tsp) inUf mode
-    -- out.normalize
+    -- let out := out.normalize
     out
   else if inEuf.isNaN then EUnpackedFloat.mkNaN
   else EUnpackedFloat.mkInfinity inEuf.sign
@@ -989,28 +993,5 @@ def checkRoundCorrect (EUnpacked SUnpackedNoHidden : Nat)
 -- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RNE
 -- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTZ
 -- #guard_msgs(error) in #eval checkRoundCorrect 2 6 2 4 .RTP
-/--
-error: (948 succeeded / 960 total) (98.750000% succeeded) (12 failures) ❌
-
-Failed ❌ | original EUNum(- 0b111000=nat:56 * 2^(0b10111=int:-9 - 5))
-  original (packed) - (subnorm:true) sig:0b00111=nat:7 ex:0b0000=nat:0 bias:7 expval:-7 = (some -7/2048)
-  original (Q) some (-7 : Rat)/2048
-  original (eunpacked) "EUNum(- 0b111000=nat:56 * 2^(0b10111=int:-9 - 5))"
-  --
-  output rounded (eunpacked) EUNum(- 0b000=nat:0 * 2^(0b00000=int:0 - 2))
-  output rounded (eunpacked.Q) ExtRat.Number 0
-  output rounded (packed) - (subnorm:false) sig:0b00=nat:0 ex:0b0111=nat:7 bias:7 expval:0 = (some -1)
-  output rounded (packed.Q) ExtRat.Number -1
-  --
-  expected (packed) - (subnorm:false) sig:0b00=nat:0 ex:0b0000=nat:0 bias:7 expval:-7 = (some 0)
-  expected (Q) ExtRat.Number 0
-  expected (eunpacked) EUNum(- 0b000=nat:0 * 2^(0b10000=int:-16 - 2))
-
-
---- blastSmtLibRound: { sign := true, ex := 0x17#5, sig := 0x38#6 } ---
-  input: - 0b111000=nat:56 * 2^(0b10111=int:-9 - 5)
-  val (Q): -7/2048 = sig(0b111000=nat:56)) * 2 ** exp:([0b10111=int:-9] - (5))
-result(EUNum): EUNum(- 0b000=nat:0 * 2^(0b00000=int:0 - 2)) | (Q): ExtRat.Number 0resultPacked: - (subnorm:false) sig:0b00=nat:0 ex:0b0111=nat:7 bias:7 expval:0 = (some -1) | (Q): -1
--/
 #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTP
--- #guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN
+#guard_msgs(error) in #eval checkRoundCorrect 4 5 4 2 .RTN

--- a/Main.lean
+++ b/Main.lean
@@ -265,7 +265,7 @@ def test_roundCircuitAgainstSmtlib (ein sin eout sout : Nat) : IO ExitCode := do
       let pf := e2m4.packedFloatOfNat x
       if pf.isNaN then continue
       let roundSmt : PackedFloat e2m2.e e2m2.m := Fp.SmtLibSemanticsEnumerator.computableSmtLibRound rm pf.sign pf.unpack.toExtRat
-      let roundCircuit : PackedFloat e2m2.e e2m2.m := (pf.unpack |>.blastRound rm (tep := e2m2.e) (tsp := e2m2.m)).pack
+      let roundCircuit : PackedFloat e2m2.e e2m2.m := (pf.unpack |>.blastSmtLibRound e2m2.e e2m2.m rm ).pack
 
       if roundSmt.equal_denotation roundCircuit then
         nsuccess := nsuccess + 1


### PR DESCRIPTION
This breaks our proof obligation down into showing the SMT-LIB ~ circuit simulation (which is already bitblastable), followed by circuit simluation ~ faster shortbuts (which will need some more theorems to be proven).

This cuts the risk of the unpacked rounding dragging on forever: It forces us to prove the key theorems to get the bitblaster working, allowing us to then implement the 'tricks' in the SymFPU circuit as a refinement.