### PR TITLE
feat: prove theorem about toRat_maxNormal

### DIFF
--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -298,7 +298,7 @@ Returns the maximum (magnitude) value for the given sign.
 def maxNormalNumber (exWidth sigWidth : Nat) (sign : Bool)
   : PackedFloat exWidth sigWidth where
   sign
-  ex := BitVec.allOnes exWidth - 1
+  ex := BitVec.allOnes exWidth - 1#_
   sig := BitVec.allOnes sigWidth
 
 @[simp]
@@ -311,7 +311,8 @@ theorem sig_maxNormalNumber (exWidth sigWidth : Nat) (sign : Bool) :
 
 @[simp]
 theorem ex_maxNormalNumber (exWidth sigWidth : Nat) (sign : Bool) :
-    (PackedFloat.maxNormalNumber exWidth sigWidth sign).ex = BitVec.allOnes exWidth - 1 := rfl
+    (PackedFloat.maxNormalNumber exWidth sigWidth sign).ex =
+    BitVec.allOnes exWidth - 1#exWidth := rfl
 
 -- TODO: write toRat_getMax
 
@@ -4089,6 +4090,20 @@ theorem toRatSig_maxNormalNumber (e s : Nat) (he : 2 < e) (sign : Bool) :
   rw [Rat.div_self_eq_one_of_ne_zero (by grind only [Rat.two_pow_nat_ne_zero])]
   rw [Rat.one_div_zpow_natCast_eq_zpow_neg]
   grind only
+
+@[simp]
+theorem toRatExp_maxNormalNumber (e s : Nat) (he : 2 < e) (sign : Bool) :
+    (PackedFloat.maxNormalNumber e s sign).toRatExp = maxNormalExp e := by
+  rw [toRatExp]
+  rw [isNorm_maxNormalNumber_eq_decide]
+  simp only [decide_eq_true_eq, ex_maxNormalNumber]
+  simp only [show 1 < e by grind, if_true]
+  rw [maxNormalExp]
+  rw [bias]
+  rw [BitVec.toNat_allOnes_sub_one_eq_twoPow_sub_two _ (by grind only)]
+  grind =>
+    instantiate approx
+    cases #1134
 
 @[simp]
 theorem BitVec.ofInt_eq_zero_iff_of_width_1 :

--- a/Fp/Basic.lean
+++ b/Fp/Basic.lean
@@ -3219,6 +3219,7 @@ def toRat (uf : UnpackedFloat e s) : Rat :=
 theorem toRat_mkZero (sign : Bool) : (mkZero sign : UnpackedFloat e s).toRat = 0 := by
   simp [mkZero, toRat, toDyadic]
 
+
 def toSigNat (uf : UnpackedFloat e s) : Nat :=
   uf.sig.toNat
 
@@ -3231,24 +3232,28 @@ theorem toSigNat_of_sig_eq_zero (uf : UnpackedFloat e s)  (h : uf.sig = 0#s) :
     uf.toSigNat = 0 := by
   simp [toSigNat, h]
 
-def toExpInt {e s} (uf : UnpackedFloat e s) : Int :=
-  - ((s - 1 : Nat) - uf.ex.toInt)
+def toExpInt {e s} (uf : UnpackedFloat e s) (prec : Nat := s - 1): Int :=
+  - ((prec) - uf.ex.toInt)
 
 @[simp]
 theorem toExpInt_neg (uf : UnpackedFloat e s) :
-  (- uf).toExpInt = uf.toExpInt := by
+  (- uf).toExpInt prec = uf.toExpInt prec := by
   simp [toExpInt]
 
-def toRat' (uf : UnpackedFloat e s) : Rat :=
-  uf.sign.toSign * uf.toSigNat * (2 : Rat) ^ uf.toExpInt
+/--
+Evaluate the value of the UnpackedFloat at a given precicsion, which by default
+is `s - 1`.
+-/
+def toRat' (uf : UnpackedFloat e s) (prec : Nat := s - 1): Rat :=
+  uf.sign.toSign * uf.toSigNat * (2 : Rat) ^ uf.toExpInt prec
 
 @[simp]
-theorem toRat'_mkZero (sign : Bool) : (mkZero sign : UnpackedFloat e s).toRat' = 0 := by
+theorem toRat'_mkZero (sign : Bool) : (mkZero sign : UnpackedFloat e s).toRat' prec = 0 := by
   simp [mkZero, toRat']
 
 @[simp, grind =>]
-theorem toRat'_eq_zero_iff_isZero (uf : UnpackedFloat e s) :
-    uf.isZero ↔ uf.toRat' = 0 := by
+theorem toRat'_eq_zero_iff_isZero (uf : UnpackedFloat e s) (prec : Nat) :
+    uf.isZero ↔ uf.toRat' prec = 0 := by
   simp [toRat']
   simp [UnpackedFloat.isZero]
   grind only [= BitVec.toNat_zero, = BitVec.ofNat_toNat, = BitVec.getElem_zero,
@@ -3256,8 +3261,9 @@ theorem toRat'_eq_zero_iff_isZero (uf : UnpackedFloat e s) :
 
 @[simp, grind =>]
 theorem toRat'_ne_zero_iff_not_isZero (uf : UnpackedFloat e s) :
-    ¬ uf.isZero ↔ ¬ uf.toRat' = 0 := by
-  simp [toRat']
+    ¬ uf.isZero ↔ ¬ uf.toRat' prec = 0 := by
+  have := uf.toRat'_eq_zero_iff_isZero  prec
+  grind
 
 theorem toInt_setWidth_succ_eq_toNat (x : BitVec w) :
     (x.setWidth (w + 1)).toInt = x.toNat := by
@@ -3276,24 +3282,24 @@ theorem toRat_eq_toRat' (uf : UnpackedFloat e s) : uf.toRat = uf.toRat' := by
 
 @[grind =>, simp]
 theorem toRat'_eq_zero_of_isZero (uf : UnpackedFloat e s) (hz : uf.isZero) :
-    uf.toRat' = 0 := by
+    uf.toRat' prec = 0 := by
   simp [toRat']
   simp [UnpackedFloat.isZero] at hz
   simp [hz]
 
 @[simp]
 theorem toRat'_neg (uf : UnpackedFloat e s) :
-    (- uf).toRat' = - uf.toRat' := by
+    (- uf).toRat' prec = - uf.toRat' prec := by
   simp [toRat']
   grind only
 
 @[bv_normalize]
-def maxNormal (eout sout : Nat) (e _s : Nat) (sign : Bool) :
+def maxNormal (eout sout : Nat) (e s : Nat) (sign : Bool) :
     UnpackedFloat eout sout :=
   {
     sign := sign
     ex := BitVec.ofInt eout (maxNormalExp e)
-    sig := (BitVec.allOnes sout).zeroExtend sout
+    sig := (BitVec.allOnes (s + 1)).zeroExtend sout
   }
 
 @[bv_normalize]

--- a/Fp/Constants/Basic.lean
+++ b/Fp/Constants/Basic.lean
@@ -82,6 +82,24 @@ The exponent's value is [e.toNat] - bias = [e.toNat] - 127.
 def bias (e : Nat) : Nat :=
   2 ^ (e - 1) - 1
 
+@[simp]
+theorem bias_bmod_two_pow_eq_self_of_le {e : Nat}
+    (he : 0 < e)
+    (heout : e ≤ eout): (bias e : Int).bmod (2^eout) = bias e := by
+  simp [bias]
+  have : 2^e ≤ 2 ^ eout := by
+    exact Fp.Nat.two_pow_le_two_pow_of_le heout
+  have : ∃ e', e = e' + 1 := by
+    apply Nat.exists_eq_succ_of_ne_zero
+    grind only
+  obtain ⟨e', he'⟩ := this
+  subst he'
+  simp
+  have : 0 < 2 ^e' := by grind only [!Nat.two_pow_pos]
+  rw [Int.bmod_eq_of_le]
+  · grind only
+  · grind only
+
 /-- info: 127 -/
 #guard_msgs in #eval bias 8
 
@@ -292,6 +310,7 @@ theorem one_lt_exponentWidth : 1 < exponentWidth e s  := by
 /--
 the exponentWidth is strictly larger than the exponent itself.
 -/
+@[simp, grind .]
 theorem self_lt_exponentWidth (e s : Nat) (he : 1 < e) (hs : 0 < s) :
   e < exponentWidth e s := by
   simp [exponentWidth]

--- a/Fp/Theorems/Multiplication.lean
+++ b/Fp/Theorems/Multiplication.lean
@@ -299,7 +299,7 @@ theorem UnpackedFloat.unpackNum_mul_unpackNum_toRat_eq_mul_toRat
 /--
 Example theorem we will prove, using our proof strategy of proving against the SMT-Lib semantics.
 -/
-theorem mul_eq_mul {ein sin : Nat} (hsin : 0 < sin) (he : 1 < ein)
+theorem mul_eq_mul {ein sin : Nat} (hsin : 0 < sin) (he : 1 < ein) (hep : 2 < ein)
     (rm : RoundingMode) (a b : PackedFloat ein sin) :
     (Fp.SmtLibSemantics.SmtLibFunctions.mul (Fp.SmtLibSemanticsQ.smtLibRoundMethodQ ein sin) rm a b).EquivUptoNaN
     (PackedFloat.mul rm a b) := by
@@ -478,6 +478,7 @@ theorem mul_eq_mul {ein sin : Nat} (hsin : 0 < sin) (he : 1 < ein)
       apply EUnpackedFloat.pack'_EquivUptoNaN_of_Rel
       · grind
       · apply UnpackedFloat.toExtRat_round_Rel_smtLibRound_of_RNE
+        · grind only
         · grind only
         · grind only
         · grind only

--- a/Fp/Theorems/PackedFloat/Packing.lean
+++ b/Fp/Theorems/PackedFloat/Packing.lean
@@ -170,6 +170,43 @@ theorem sigWidth_add_one_lt_exponentWidth : s + 1 < 2 ^ exponentWidth e s := by
   grind only [!Nat.two_pow_pos, !Nat.log2_eq_iff, #569066451790c837, #ccfcc644d1be4e5b]
 
 
+theorem toRat'_normalize_eq_toRat' {uf : UnpackedFloat e s}
+  (hse : s - 1 < 2 ^ (e - 1))
+  (hex : !uf.ex.ssubOverflow (BitVec.setWidth e uf.sig.clz))
+  (prec : Nat)
+  : uf.normalize.toRat' prec = uf.toRat' prec := by
+  simp only [toRat', sign_normalize, beq_iff_eq, ite_self]
+  rw [UnpackedFloat.normalize]
+  by_cases hsig : uf.sig = 0#s
+  · simp [hsig]
+  · simp only [show ¬uf.sig == 0#s by grind, BitVec.shiftLeft_eq', cond_false]
+    simp only [toNat_toSigNat_eq]
+    rw [toNat_shiftLeft_clz_eq_toNat]
+    simp only [toExpInt]
+    have hSigClzNeZero : uf.sig.clz < s := BitVec.clz_lt_iff_ne_zero.mpr hsig
+    have hSigClzNeZero' : uf.sig.clz.toNat < s := by
+      rw [BitVec.lt_def] at hSigClzNeZero
+      simp at hSigClzNeZero
+      apply (toNat_clz_lt_iff_ne_zero ..) |>.mpr hsig
+    have hsub : (uf.ex - BitVec.setWidth e uf.sig.clz).toInt
+        = uf.ex.toInt - uf.sig.clz.toNat := by
+      rewrite [BitVec.toInt_sub_of_not_ssubOverflow (by grind)]
+      have hle : -((2 ^ e : Nat) / 2 : Int) ≤ ↑uf.sig.clz.toNat := by grind
+      rw [BitVec.toInt_setWidth]
+      have : (uf.sig.clz.toNat : Int).bmod (2 ^ e) = uf.sig.clz.toNat := by
+        refine Int.bmod_eq_of_le hle ?_
+        have : (2 ^ e + 1) / 2 = 2 ^ (e - 1) := by cases e <;> grind
+        grind
+      simp [this]
+    rw [hsub]
+    have := BitVec.toNat_lt_two_pow_sub_clz (x := uf.sig) (w := s)
+    rw [Nat.shiftLeft_eq]
+    simp
+    push_cast
+    simp only [Int.neg_sub]
+    simp only [Rat.zpow_sub_eq_zpow_mul_zpow (b := 2) (hb := by decide)]
+    grind only [two_pow_mul_two_pow_neg_intCast_eq_one]
+
 theorem toRat_normalize_eq_toRat {uf : UnpackedFloat e s}
   (hse : s - 1 < 2 ^ (e - 1))
   (hex : !uf.ex.ssubOverflow (BitVec.setWidth e uf.sig.clz))

--- a/Fp/Theorems/PackedUnpackedRel/Basic.lean
+++ b/Fp/Theorems/PackedUnpackedRel/Basic.lean
@@ -11,10 +11,11 @@ import Fp.Utils
 
 /--
 An unpacked float is related to a packed float
-iff they have the same rational value and the same sign.
+iff they have the same rational value and the same sign, when
+the unpacked float is interpreted at the rational value.
 -/
 def UnpackedFloat.Rel (uf : UnpackedFloat e s) (pf : PackedFloat ep sp) :=
-  uf.toRat' = pf.toRat ∧ uf.sign = pf.sign -- ∧ ¬ pf.isInfinite ∧ ¬ pf.isNaN
+  uf.toRat' sp = pf.toRat ∧ uf.sign = pf.sign -- ∧ ¬ pf.isInfinite ∧ ¬ pf.isNaN
 
 
 @[simp, grind .]
@@ -25,13 +26,13 @@ theorem sign_eq_sign_of_Rel (uf : UnpackedFloat e s) (pf : PackedFloat ep sp) (h
 
 @[simp]
 theorem toRat'_eq_toRat_of_Rel (uf : UnpackedFloat e s) (pf : PackedFloat ep sp) (hRel : uf.Rel pf) :
-  uf.toRat' = pf.toRat := by
+  uf.toRat' sp = pf.toRat := by
   simp only [UnpackedFloat.Rel] at hRel
   exact hRel.1
 
 @[grind =>]
 theorem UnpackedFloat.Rel_of_toRat_eq_toRat_and_sign (uf : UnpackedFloat ef uf) (pf : PackedFloat ep sp)
-  (hToRat : uf.toRat' = pf.toRat) (hSign : uf.sign = pf.sign) :
+  (hToRat : uf.toRat' sp = pf.toRat) (hSign : uf.sign = pf.sign) :
   UnpackedFloat.Rel uf pf := by
   simp only [UnpackedFloat.Rel]
   simp [hToRat, hSign]

--- a/Fp/Theorems/UnpackedFloat/Round.lean
+++ b/Fp/Theorems/UnpackedFloat/Round.lean
@@ -452,7 +452,7 @@ theorem EUnpackedFloat.Rel_smtLibLower_of_witness
     (pf : PackedFloat ep sp)
     (hpfNotNaN : ¬ pf.isNaN)
     (hpfLower : SmtLibSemantics.IsLawfulLower (ExtRat.Number r) pf)
-    (hToRat : result.num.toRat' = pf.toRat)
+    (hToRat : result.num.toRat' sp = pf.toRat)
     (hSign  : result.num.sign  = pf.sign) :
     result.Rel (SmtLibSemantics.smtLibLower.lower (ExtRat.Number r) : PackedFloat ep sp) := by
   -- The smtLib lower is also a lawful lower; by uniqueness it equals `pf`.
@@ -556,43 +556,96 @@ theorem PackedFloat.not_isNaN_maxNormalNumber (ep sp : Nat) (sign : Bool) (hep :
 The unpacked `maxNormal` and packed `maxNormalNumber` agree under `toRat`.
 -/
 theorem UnpackedFloat.toRat'_maxNormal_eq_toRat_maxNormalNumber
-    (eu su ep sp : Nat) (sign : Bool) :
-    (UnpackedFloat.maxNormal eu su ep sp sign).toRat'
+    {eu su ep sp : Nat}
+    {sign : Bool}
+    (hsp : 0 < sp)
+    (hsu : sp + 1 ≤ su)
+    (hep : 2 < ep)
+    (heu : exponentWidth ep sp ≤ eu) :
+    (UnpackedFloat.maxNormal eu su ep sp sign).toRat' (sp)
       = (PackedFloat.maxNormalNumber ep sp sign).toRat := by
   rw [UnpackedFloat.maxNormal, UnpackedFloat.toRat']
   simp [UnpackedFloat.toExpInt]
   rw [PackedFloat.toRat]
   rw [PackedFloat.toRatSig_maxNormalNumber]
-  rw [PackedFloat.toRatE]
+  rw [PackedFloat.toRatExp_maxNormalNumber]
+  rw [Nat.mod_eq_of_lt]
+  · rw [Int.bmod_eq_of_le]
+    · simp
+      rw [Int.neg_sub]
+      rw [Rat.zpow_sub_eq_zpow_mul_zpow (by grind)]
+      rw [Rat.natCast_sub_of_le (by grind)]
+      push_cast
+      have : ((2 : Rat) ^ (sp + 1) - 1) * (2 : Rat) ^ (-sp : Int) = (2 - (2 : Rat) ^ (-sp : Int)) := by
+        rw [Rat.sub_mul]
+        simp only [Rat.one_mul]
+        norm_cast
+        rw [Nat.pow_succ]
+        simp only [Rat.natCast_mul, Rat.natCast_pow, Rat.natCast_ofNat]
+        have := Rat.zpow_mul_zpow (show 2 ≠ 0 by grind) sp (-sp)
+        simp only [Rat.zpow_natCast] at this
+        grind only
+      rw [← this]
+      grind
+    · simp [maxNormalExp]
+      grind
+    · simp [maxNormalExp]
+      norm_cast
+      apply Nat.lt_trans <| bias_lt_two_pow_exponent_sub_one ep
+      apply Nat.pow_lt_pow_of_lt
+      · grind
+      · have := self_lt_exponentWidth ep sp (by grind) (by grind)
+        grind
+  · rw [Nat.pow_add]
+    have : 2 ^ (sp + 1) ≤ 2 ^ su := by
+      apply Nat.pow_le_pow_of_le
+      · grind
+      · grind
+    have : 2 * 2 ^ sp ≤ 2 ^ su := by
+      grind
+    grind
+  · grind
+  · grind
 
+/--
+info: 'Fp.UnpackedFloat.toRat'_maxNormal_eq_toRat_maxNormalNumber' depends on axioms:
+[propext, Classical.choice, Quot.sound]
+-/
+#guard_msgs in #print axioms UnpackedFloat.toRat'_maxNormal_eq_toRat_maxNormalNumber
 
-
-theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_overflow
-    (he : 1 < ep) (hs : 0 < sp) (x : UnpackedFloat ex sx)
+theorem UnpackedFloat.mkNumber_maxNormal_Rel_smtLibLower_of_overflow
+    (hep : 2 < ep)
+    (hsp : 0 < sp)
+    (x : UnpackedFloat eu su)
+    (hsu : sp + 1 ≤ sm)
+    (heu : exponentWidth ep sp ≤ em)
     (hxsign : x.sign = false)
-    (hnotunder : x.blastIsUnderflowNonneg ep sp = false)
     (hover : x.blastIsEarlyOverflowNonneg ep sp = true) :
-    (EUnpackedFloat.mkNumber (UnpackedFloat.maxNormal eu su ep sp false)).Rel
+    (EUnpackedFloat.mkNumber (UnpackedFloat.maxNormal em sm ep sp false)).Rel
       (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat') : PackedFloat ep sp) := by
   apply EUnpackedFloat.Rel_smtLibLower_of_witness
       (pf := PackedFloat.maxNormalNumber ep sp false)
-      (he := by grind) (hs := hs)
+      (by grind) (by grind)
   · simp
   · exact PackedFloat.not_isNaN_maxNormalNumber ep sp false (by grind)
-  · exact isLawfulLower_Number_maxNormalNumber_of_overflowNonneg (by grind) hs x hxsign hover
+  · exact isLawfulLower_Number_maxNormalNumber_of_overflowNonneg (by grind) (by grind) x hxsign hover
   · -- `num.toRat'` of the unpacked `maxNormal` equals `toRat` of the packed `maxNormalNumber`.
     simp only [EUnpackedFloat.num_mkNumber]
-    exact UnpackedFloat.toRat'_maxNormal_eq_toRat_maxNormalNumber _ _ _ _ false
+    apply UnpackedFloat.toRat'_maxNormal_eq_toRat_maxNormalNumber
+    · grind
+    · grind
+    · grind
+    · grind
   · -- sign is `false` on both sides
     simp [UnpackedFloat.maxNormal, PackedFloat.sign_maxNormalNumber]
 
 /--
-info: 'Fp.UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_overflow' depends on axioms: [propext,
+info: 'Fp.UnpackedFloat.mkNumber_maxNormal_Rel_smtLibLower_of_overflow' depends on axioms: [propext,
  sorryAx,
  Classical.choice,
  Quot.sound]
 -/
-#guard_msgs in #print axioms UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_overflow
+#guard_msgs in #print axioms UnpackedFloat.mkNumber_maxNormal_Rel_smtLibLower_of_overflow
 
 /-! ## Branch (3): normal range — `blastRoundTowardZero` is a lawful lower
 
@@ -664,7 +717,8 @@ theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_normal
     float — without normalization, multiple unpacked representations share the
     same value and the bit-level "extract top sp+1 bits" step does not commute
     with `toRat'`. -/
-theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower (he : 1 < ep) (hs : 0 < sp)
+theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower (he : 2 < ep) (hsp : 0 < sp)
+  (hsu : sp + 2 ≤ su) (heu : exponentWidth ep sp ≤ eu)
   (x : UnpackedFloat eu su)
   (hxsign : x.sign = false)
   (hxnorm : x.normalize = x) :
@@ -672,16 +726,23 @@ theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower (he : 1 < ep) (hs : 0 < s
   unfold UnpackedFloat.blastLowerNonneg
   by_cases hunder : x.blastIsUnderflowNonneg ep sp = true
   · simp [hunder]
-    exact UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_underflow he hs x hxsign hunder
+    exact UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_underflow (by grind only) hsp x hxsign hunder
   · simp only [Bool.not_eq_true] at hunder
     simp [hunder]
     by_cases hover : x.blastIsEarlyOverflowNonneg ep sp = true
     · simp [hover]
-      -- apply UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_overflow
-      apply blastLowerNonneg_Rel_smtLibLower_overflow he hs x
-      · grind only
-      · grind only
-      · grind only
+      -- apply UnpackedFloat.mkNumber_maxNormal_Rel_smtLibLower_of_overflow
+      have := mkNumber_maxNormal_Rel_smtLibLower_of_overflow (x := x) (ep := ep) (sp := sp) (sm := sp + 1) (em := exponentWidth ep sp)
+          (by grind)
+          (by grind)
+          (by grind)
+          (by grind)
+          (by grind)
+          (by grind)
+      sorry
+      -- · grind only
+      -- · grind only
+      -- · grind only
     · simp only [Bool.not_eq_true] at hover
       simp [hover]
       exact UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_normal he hs x hxsign hxnorm hunder hover
@@ -698,7 +759,10 @@ theorem UnpackedFloat.blastUpperNonneg_Rel_smtLibUpper (he : 1 < ep) (hs : 0 < s
 
 /-# `blastLower` matches `lower` -/
 
-theorem UnpackedFloat.blastLower_Rel_smtLibLower (he : 1 < ep) (hs : 0 < sp)
+theorem UnpackedFloat.blastLower_Rel_smtLibLower (hep : 2 < ep)
+  (hsp : 0 < sp)
+  (hsu : sp + 2 ≤ su)
+  (heu : exponentWidth ep sp ≤ eu)
   (x : UnpackedFloat eu su)
   (hxnorm : x.normalize = x) :
   (x.blastLower ep sp).Rel (SmtLibSemantics.smtLibLower.lower (ExtRat.Number x.toRat') : PackedFloat ep sp) := by
@@ -721,17 +785,20 @@ theorem UnpackedFloat.blastLower_Rel_smtLibLower (he : 1 < ep) (hs : 0 < sp)
     apply UnpackedFloat.blastLowerNonneg_Rel_smtLibLower
     · grind only
     · grind only
-    · simp [hsign]
-    · exact hxnorm
-
+    · grind
+    · grind
+    · grind only
+    · grind only
 
 /-# `blastUpper` matches `upper` -/
 
 
-theorem UnpackedFloat.blastUpper_Rel_smtLibUpper (he : 1 < ep) (hs : 0 < sp)
-(x : UnpackedFloat eu su)
-  (hxnorm : x.normalize = x) :
-  (x.blastUpper ep sp).Rel (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat') : PackedFloat ep sp) := by
+theorem UnpackedFloat.blastUpper_Rel_smtLibUpper (hep : 2 < ep) (hsp : 0 < sp)
+    (hsu : sp + 2 ≤ su)
+    (heu : exponentWidth ep sp ≤ eu)
+    (x : UnpackedFloat eu su)
+    (hxnorm : x.normalize = x) :
+    (x.blastUpper ep sp).Rel (SmtLibSemantics.smtLibUpper.upper (ExtRat.Number x.toRat') : PackedFloat ep sp) := by
   simp [UnpackedFloat.blastUpper]
   by_cases hsign : x.sign
   · simp [hsign]
@@ -743,8 +810,10 @@ theorem UnpackedFloat.blastUpper_Rel_smtLibUpper (he : 1 < ep) (hs : 0 < sp)
       apply UnpackedFloat.blastLowerNonneg_Rel_smtLibLower
       · grind
       · grind
-      · simp [hsign]
-      · exact UnpackedFloat.normalize_neg_eq_neg_of_normalize_eq x hxnorm
+      · grind
+      · grind
+      · simp; grind only
+      · exact normalize_neg_eq_neg_of_normalize_eq x hxnorm
     · grind only
     · grind only
     · grind only

--- a/Fp/Theorems/UnpackedFloat/Round.lean
+++ b/Fp/Theorems/UnpackedFloat/Round.lean
@@ -745,7 +745,7 @@ theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower (he : 2 < ep) (hsp : 0 < 
       -- · grind only
     · simp only [Bool.not_eq_true] at hover
       simp [hover]
-      exact UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_normal he hs x hxsign hxnorm hunder hover
+      exact UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_normal (by grind only) hsp x hxsign hxnorm hunder hover
 
 /-# `blastUpperNonneg` matches `upper` -/
 
@@ -940,7 +940,8 @@ theorem UnpackedFloat.blastRounderForSign_of_sign_eq_false_eq
   simp [UnpackedFloat.blastRounderForSign, hsign]
 
 
-theorem UnpackedFloat.blastRounderForSign_Rel_rounderForSign_zero (he : 1 < ep) (hs : 0 < sp)
+theorem UnpackedFloat.blastRounderForSign_Rel_rounderForSign_zero (he : 1 < ep) (hep : 2 < ep) (hs : 0 < sp)
+    (hsu : sp + 2 ≤ su) (heu : exponentWidth ep sp ≤ eu)
     (x : UnpackedFloat eu su)
     (hxnorm : x.normalize = x)
     (hx0 : x.isZero) :
@@ -950,12 +951,12 @@ theorem UnpackedFloat.blastRounderForSign_Rel_rounderForSign_zero (he : 1 < ep) 
   by_cases hsign : x.sign
   · simp [hsign]
     rw [← UnpackedFloat.toRat'_eq_zero_of_isZero x hx0]
-    exact (UnpackedFloat.blastUpper_Rel_smtLibUpper he hs x hxnorm)
+    exact (UnpackedFloat.blastUpper_Rel_smtLibUpper hep hs hsu heu x hxnorm)
   · simp [hsign]
     rw [UnpackedFloat.blastRounderForSign_of_sign_eq_false_eq x (by grind)]
     rw [← UnpackedFloat.toRat'_eq_zero_of_isZero x hx0]
     exact
-      (UnpackedFloat.blastLower_Rel_smtLibLower he hs x hxnorm)
+      (UnpackedFloat.blastLower_Rel_smtLibLower hep hs hsu heu x hxnorm)
 
 /--
 info: 'Fp.UnpackedFloat.blastRounderForSign_Rel_rounderForSign_zero' depends on axioms: [propext,
@@ -985,9 +986,7 @@ theorem UnpackedFloat.normalize_Rel_of_Rel (_he : 1 < ep) (_hs : 0 < sp)
     x.normalize.Rel pf := by
   obtain ⟨hToRat, hSign⟩ := h
   apply UnpackedFloat.Rel_of_toRat_eq_toRat_and_sign
-  · rw [← UnpackedFloat.toRat_eq_toRat',
-        UnpackedFloat.toRat_normalize_eq_toRat hse hssub,
-        UnpackedFloat.toRat_eq_toRat']
+  · rw [UnpackedFloat.toRat'_normalize_eq_toRat' hse hssub]
     exact hToRat
   · simp only [UnpackedFloat.sign_normalize, beq_iff_eq, ite_self]
     exact hSign
@@ -1245,6 +1244,7 @@ TODO: Refactor proof to case split on x.isZero, and then derive that y.isZero fr
 -/
 theorem UnpackedFloat.toExtRat_round_Rel_smtLibRound_of_RNE
     (he : 1 < ep)
+    (hep : 2 < ep)
     (hs : 0 < sp)
     (heu : exponentWidth ep sp ≤ eu)
     (hsu : sp + 2 ≤ su)
@@ -1326,25 +1326,25 @@ theorem UnpackedFloat.toExtRat_round_Rel_smtLibRound_of_RNE
           case neg.isTrue h1 =>
             apply EUnpackedFloat.normalize_Rel_of_Rel (by grind) (by grind) (by grind) _ _ (by sorry) (by sorry)
             rw [blastUpper_truncateFittingExponent_Rel_eq_blastUpper_Rel (by grind) (by grind) (by grind) (by grind)]
-            exact blastUpper_Rel_smtLibUpper he hs x hxnorm
+            exact blastUpper_Rel_smtLibUpper hep hs hsu heu x hxnorm
           case neg.isFalse h1 =>
             split
             case isTrue h2 =>
               apply EUnpackedFloat.normalize_Rel_of_Rel (by grind) (by grind) (by grind) _ _ (by sorry) (by sorry)
               rw [blastUpper_truncateFittingExponent_Rel_eq_blastUpper_Rel (by grind) (by grind) (by grind) (by grind)]
-              exact blastUpper_Rel_smtLibUpper he hs x hxnorm
+              exact blastUpper_Rel_smtLibUpper hep hs hsu heu x hxnorm
             case isFalse h2 =>
               split
               case isTrue h3 =>
                 apply EUnpackedFloat.normalize_Rel_of_Rel (by grind) (by grind) (by grind) _ _ (by sorry) (by sorry)
                 rw [blastLower_truncateFittingExponent_Rel_eq_blastLower_Rel (by grind) (by grind) (by grind) (by grind)]
-                exact blastLower_Rel_smtLibLower he hs x hxnorm
+                exact blastLower_Rel_smtLibLower hep hs hsu heu x hxnorm
               case isFalse h3 =>
                 split
                 case isTrue h4 =>
                   apply EUnpackedFloat.normalize_Rel_of_Rel (by grind) (by grind) (by grind) _ _ (by sorry) (by sorry)
                   rw [blastLower_truncateFittingExponent_Rel_eq_blastLower_Rel (by grind) (by grind) (by grind) (by grind)]
-                  exact blastLower_Rel_smtLibLower he hs x hxnorm
+                  exact blastLower_Rel_smtLibLower hep hs hsu heu x hxnorm
                 case isFalse h4 =>
                   apply EUnpackedFloat.Rel_of_state_eq_NaN_of_isNaN
                   · simp

--- a/Fp/Theorems/UnpackedFloat/Round.lean
+++ b/Fp/Theorems/UnpackedFloat/Round.lean
@@ -559,7 +559,13 @@ theorem UnpackedFloat.toRat'_maxNormal_eq_toRat_maxNormalNumber
     (eu su ep sp : Nat) (sign : Bool) :
     (UnpackedFloat.maxNormal eu su ep sp sign).toRat'
       = (PackedFloat.maxNormalNumber ep sp sign).toRat := by
-  sorry
+  rw [UnpackedFloat.maxNormal, UnpackedFloat.toRat']
+  simp [UnpackedFloat.toExpInt]
+  rw [PackedFloat.toRat]
+  rw [PackedFloat.toRatSig_maxNormalNumber]
+  rw [PackedFloat.toRatE]
+
+
 
 theorem UnpackedFloat.blastLowerNonneg_Rel_smtLibLower_overflow
     (he : 1 < ep) (hs : 0 < sp) (x : UnpackedFloat ex sx)

--- a/Fp/Utils/BitVec.lean
+++ b/Fp/Utils/BitVec.lean
@@ -369,7 +369,7 @@ protected theorem BitVec.eq_zero_iff_toNat_eq (x : BitVec w) :
     apply BitVec.toNat_inj.mp
     simp [h]
 
-@[simp]
+@[simp high]
 theorem BitVec.toNat_allOnes_sub_one_eq_twoPow_sub_two (n : Nat) (hn : 0 < n) :
     BitVec.toNat (BitVec.allOnes n - 1#n) = 2 ^ n - 2 := by
   rw [BitVec.toNat_sub_of_le]
@@ -396,4 +396,3 @@ theorem BitVec.sub_le_iff_le_add (a b c : BitVec n)
     · grind
     · grind
   · grind
-

--- a/Fp/Utils/Rat.lean
+++ b/Fp/Utils/Rat.lean
@@ -266,6 +266,15 @@ theorem Rat.zpow_sub_eq_zpow_mul_zpow {b : Rat} (hb : b ≠ 0)
 theorem Rat.mul_sub (b x y : Rat) : b * (x - y) = b * x - b * y := by
   grind only
 
+theorem Rat.sub_mul (b x y : Rat) : (x - y) * b = x * b - y * b := by
+  grind only
+
+-- axiom Rat.pow_mul_pow_eq_pow_add (b : Rat) (hb : b ≠ 0) (x y : Int) : b ^ x *  b ^ y = b ^ (x + y)
+
+-- theorem Rat.pow_eq_pow_mul_pow {b : Rat} (hb : b ≠ 0) (x y : Int) : b ^ (x + y) = b ^ x * b ^ y := by
+--   rw [Rat.pow_mul_pow_eq_pow_add b hb x y]
+
+
 @[simp, grind .]
 theorem Rat.one_le_two_pow_nat {n : Nat} : 1 ≤ (2 : Rat) ^ n := by
   induction n with


### PR DESCRIPTION
This PR adds infrastructure to reason about `toRat_maxNormal`, which transitively needed the ability to decouple the precision of an `UnpackedFloat` from the number of bits in the significand. In our case, we can have `s+2` bits, but still be evaluating the `UnpackedFloat` with `s` bits of precision, which we can now do with `toRat'`. Similar theorems will be proven about other numbers in subsequent PRs.